### PR TITLE
Remove files from modlinks

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -36,11 +36,6 @@
             <![CDATA[https://github.com/fifty-six/HollowKnight.QoL/releases/download/v3/QoL.zip]]>
         </Link>
         
-        <Files>
-            <File>QoL.dll</File>
-            <File>QoL.pdb</File>
-        </Files>
-        
         <Dependencies>
             <Dependency>Vasi</Dependency>
         </Dependencies>
@@ -53,11 +48,6 @@
         <Link SHA256="B93FA7ECDF40D5F91F942ACFD31CD2A5243551720C96E18DDE99FD64919162EC">
             <![CDATA[https://github.com/fifty-six/HollowKnight.Vasi/releases/download/v2/Vasi.zip]]>
         </Link>
-        
-        <Files>
-            <File>Vasi.dll</File>
-            <File>Vasi.pdb</File>
-        </Files>
         
         <Dependencies />
     </Manifest>

--- a/Schemas/ModLinks.xml
+++ b/Schemas/ModLinks.xml
@@ -21,7 +21,6 @@
       <xs:element name="Links" type="LinksType" />
       <xs:element name="Link" type="SingleLinkType" />
     </xs:choice>
-    <xs:element name="Files" type="FileListType" />
     <xs:element name="Dependencies" type="DepListType" />
   </xs:sequence>
 </xs:complexType>
@@ -40,12 +39,6 @@
       <xs:attribute name="SHA256" type="ShaStringType" use="required" />
     </xs:extension>
   </xs:simpleContent>
-</xs:complexType>
-
-<xs:complexType name="FileListType">
-  <xs:sequence minOccurs="0" maxOccurs="unbounded">
-    <xs:element name="File" type="xs:string" />
-  </xs:sequence>
 </xs:complexType>
 
 <xs:complexType name="DepListType">


### PR DESCRIPTION
Should be unnecessary with the choice of using folders for mods.