### PR TITLE
Add BingoUI port

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -260,6 +260,19 @@
         </Dependencies>
     </Manifest>
     <Manifest>
+        <Name>BingoUI</Name>
+        <Description>Automatic tracking of bingo goals for bingo speedrun races.</Description>
+        <Version>2.0.0.0</Version>
+        
+        <Link SHA256="4d99a1cbffd777bf9cb089ef5f719d161fe14278e6877323e7deac26258bf12b">
+            <![CDATA[https://github.com/flibber-hk/HollowKnight.BingoUI/releases/download/v2.0/BingoUI.zip]]>
+        </Link>
+        
+        <Dependencies>
+            <Dependency>Vasi</Dependency>
+        </Dependencies>
+    </Manifest>
+    <Manifest>
         <Name>Benchwarp</Name>
         <Description>Mod for selecting and warping to benches. Also allows placing benches and warping to room transitions.</Description>
         <Version>3.1.1.0</Version>


### PR DESCRIPTION
Requires itemchanger to build, but works with itemchanger installed or not. (Vasi is required tho)