### PR TITLE
Add HideModList mod

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -691,6 +691,15 @@ Enjoy!</Description>
 		</Dependencies>
 	</Manifest>-->
     <Manifest>
+        <Name>HideModList</Name>
+        <Description>A simple mod to hide your modlist for whatever reason</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="75AAB34EFEA9A5050C358141C58DA5760EC4EA24F8CC5F1D00B29B1D951E48BD">
+            <![CDATA[https://github.com/TheMulhima/HollowKnight.HideModList/releases/download/v1.0/HideModList.zip]]>
+        </Link>
+        <Dependencies />
+    </Manifest>
+    <Manifest>
         <Name>RandomTeleport</Name>
         <Description>A mod that randomly teleports you to another scene</Description>
         <Version>0.0.3.1</Version>


### PR DESCRIPTION
A few things to note:
1) This doesn't completely remove the modlist (Modding API text is still seen) [(see example)](https://github.com/TheMulhima/HollowKnight.HideModList/blob/master/ReadmeAssets/Example.png)
2) An [IL hook](https://github.com/TheMulhima/HollowKnight.HideModList/blob/30dfe11badeddf1d0f9ac6a675561ac8d8daed72/HideModList/HideModList.cs#L62-L75) was used to make it less replicable.

So this really shouldn't cause issues for speedrun verifications