### PR TITLE
Add Grey Prince Zote mod.

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -22,7 +22,7 @@
     <Manifest>
         <Name>PureZote</Name>
         <Description>Enabled Grey Prince Zote to summon Eternal Ordeal and upgraded its skills.</Description>
-        <Version>0.1</Version>
+        <Version>0.1.0.0</Version>
         <Link SHA256="9c27491d805b3a8e197aabb65922dd9be3a07a26660facad88cf1754bc6ba94c">
             <![CDATA[https://github.com/yunjord/PureZote/releases/download/0.1/PureZote.0.1.zip]]>
         </Link>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -20,6 +20,17 @@
 	</Manifest>
 	-->
     <Manifest>
+        <Name>PureZote</Name>
+        <Description>Enabled Grey Prince Zote to summon Eternal Ordeal and upgraded its skills.</Description>
+        <Version>0.1</Version>
+        <Link SHA256="9c27491d805b3a8e197aabb65922dd9be3a07a26660facad88cf1754bc6ba94c">
+            <![CDATA[https://github.com/yunjord/PureZote/releases/download/0.1/PureZote.0.1.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>Satchel</Dependency>
+        </Dependencies>
+    </Manifest>
+    <Manifest>
         <Name>SteelSoulHUD</Name>
         <Description>Enables the Steel Soul HUD in normal mode.</Description>
         <Version>1.0.0.0</Version>


### PR DESCRIPTION
This mod enabled Grey Prince Zote to summon Eternal Ordeal and upgraded its skills. See https://github.com/yunjord/PureZote/releases/download/0.1/showcase.1.png and https://github.com/yunjord/PureZote/releases/download/0.1/showcase.2.png