### PR TITLE
Update MagicUI and MajorItemsByAreaTracker

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -933,9 +933,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>MagicUI</Name>
         <Description>A core mod to help other mods build UIs. Does nothing on its own.</Description>
-        <Version>1.1.8112.42592</Version>
-        <Link SHA256="0CA2AC3FE0E7C1583F49CC3AA2EC05A36FDD35564A2E31AB12BC49BCA6263C56">
-            <![CDATA[https://github.com/BadMagic100/HollowKnight.MagicUI/releases/download/v1.1.8112.42592/MagicUI.zip]]>
+        <Version>1.2.8160.1743</Version>
+        <Link SHA256="856EE6D0B11CBF2BD0A91FB497F3BA07E493C41002036EB9322FDD1683A22F19">
+            <![CDATA[https://github.com/BadMagic100/HollowKnight.MagicUI/releases/download/v1.2.8160.1743/MagicUI.zip]]>
         </Link>
         <Dependencies />
     </Manifest>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1194,9 +1194,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>MagicUI</Name>
         <Description>A core mod to help other mods build UIs. Does nothing on its own.</Description>
-        <Version>1.2.8160.1743</Version>
-        <Link SHA256="856EE6D0B11CBF2BD0A91FB497F3BA07E493C41002036EB9322FDD1683A22F19">
-            <![CDATA[https://github.com/BadMagic100/HollowKnight.MagicUI/releases/download/v1.2.8160.1743/MagicUI.zip]]>
+        <Version>1.3.8166.1420</Version>
+        <Link SHA256="B4B16E64E807CE925273D81B0DE875708392295C4571D122231B2D3033CD0AA5">
+            <![CDATA[https://github.com/BadMagic100/HollowKnight.MagicUI/releases/download/v1.3.8166.1420/MagicUI.zip]]>
         </Link>
         <Dependencies />
         <Repository>
@@ -1241,9 +1241,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>MajorItemByAreaTracker</Name>
         <Description>A randomizer connection that adds a semi-spoiler randomizer game mode with an in-game tracker.</Description>
-        <Version>1.1.2.0</Version>
-        <Link SHA256="ECB0BCA4CC8A663DB81686EB4634384D580CB31832D710A2EE2ADB9F0F9397AD">
-            <![CDATA[https://github.com/BadMagic100/MajorItemByAreaTracker/releases/download/v1.1.2.0/MajorItemByAreaTracker.zip]]>
+        <Version>1.1.3.0</Version>
+        <Link SHA256="7925F78F43E71D0C9E003C1945CE3E275DEEA24DD87BAF715DD5E479251C81D0">
+            <![CDATA[https://github.com/BadMagic100/MajorItemByAreaTracker/releases/download/v1.1.3.0/MajorItemByAreaTracker.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -949,9 +949,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>MajorItemByAreaTracker</Name>
         <Description>A randomizer connection that adds a semi-spoiler randomizer game mode with an in-game tracker.</Description>
-        <Version>1.1.1.0</Version>
-        <Link SHA256="35FA6A99384821326EBF7C919B6EA7E0ADD70B5365336592FD2A739751889335">
-            <![CDATA[https://github.com/BadMagic100/MajorItemByAreaTracker/releases/download/v1.1.1.0/MajorItemByAreaTracker.zip]]>
+        <Version>1.1.2.0</Version>
+        <Link SHA256="ECB0BCA4CC8A663DB81686EB4634384D580CB31832D710A2EE2ADB9F0F9397AD">
+            <![CDATA[https://github.com/BadMagic100/MajorItemByAreaTracker/releases/download/v1.1.2.0/MajorItemByAreaTracker.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>


### PR DESCRIPTION
I don't know why github is being like this with respect to the already-merged commits...