### PR TITLE
Added FallDamage

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -25,6 +25,23 @@
         </Tags>
     </Manifest>
     -->
+	<Manifest>
+		<Name>FallDamage</Name>
+		<Description>Player takes fall damage proportional to their max health and time spent falling.</Description>
+		<Version>1.0.0.0</Version>
+		<Link SHA256="395610C98A5443EB9D3C57C86E0C2D233B133C990F8FF09823EED68AF7E239DF">
+			<![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage/releases/download/v1.0.0/FallDamage.zip]]>
+		</Link>
+		<Dependencies>
+			<Dependency>Satchel</Dependency>
+		</Dependencies>
+		<Repository>
+			<![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage]]>
+		</Repository>
+		<Tags>
+			<Tag>Gameplay</Tag>
+		</Tags>
+	</Manifest>
     <Manifest>
         <Name>CriticalSlash</Name>
         <Description>Makes nail arts deal extra damage and return control faster if released at the earliest moment.</Description>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -28,9 +28,9 @@
     <Manifest>
         <Name>FallDamage</Name>
         <Description>Player takes fall damage proportional to their max health and time spent falling.</Description>
-        <Version>1.0.0.0</Version>
-        <Link SHA256="395610C98A5443EB9D3C57C86E0C2D233B133C990F8FF09823EED68AF7E239DF">
-            <![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage/releases/download/v1.0.0/FallDamage.zip]]>
+        <Version>1.1.0.0</Version>
+        <Link SHA256="3707FD192891049B8105E7ECAC63098C759B1937CD56099D165F161F25B5178E">
+            <![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage/releases/download/v1.1.0/FallDamage.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -25,23 +25,23 @@
         </Tags>
     </Manifest>
     -->
-	<Manifest>
-		<Name>FallDamage</Name>
-		<Description>Player takes fall damage proportional to their max health and time spent falling.</Description>
-		<Version>1.0.0.0</Version>
-		<Link SHA256="395610C98A5443EB9D3C57C86E0C2D233B133C990F8FF09823EED68AF7E239DF">
-			<![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage/releases/download/v1.0.0/FallDamage.zip]]>
-		</Link>
-		<Dependencies>
-			<Dependency>Satchel</Dependency>
-		</Dependencies>
-		<Repository>
-			<![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage]]>
-		</Repository>
-		<Tags>
-			<Tag>Gameplay</Tag>
-		</Tags>
-	</Manifest>
+    <Manifest>
+        <Name>FallDamage</Name>
+        <Description>Player takes fall damage proportional to their max health and time spent falling.</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="395610C98A5443EB9D3C57C86E0C2D233B133C990F8FF09823EED68AF7E239DF">
+            <![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage/releases/download/v1.0.0/FallDamage.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>Satchel</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/Makeit-Hardcore/HK-FallDamage]]>
+        </Repository>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+    </Manifest>
     <Manifest>
         <Name>CriticalSlash</Name>
         <Description>Makes nail arts deal extra damage and return control faster if released at the earliest moment.</Description>


### PR DESCRIPTION
FallDamage is a mod I developed to, well, add fall damage to Hollow Knight. Damage taken is proportional to player max health and time spent falling, with the minimum amount of time for damage to occur being that of the hardfall animation. Timer is controlled by existing game code and therefore resets upon actions such as wings, VS, cloak, etc. Dive is immune from damage. Comes with a toggle menu and a secondary mode Glass Ankles where minimum fall timer requirement is halved and damage is therefore increased.