### PR TITLE
Rename "Damage Values" to DamageValues

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -200,7 +200,7 @@
         </Tags>
     </Manifest>
     <Manifest>
-        <Name>Damage Values</Name>
+        <Name>DamageValues</Name>
         <Description>Shows damage numbers when striking an enemy.</Description>
         <Version>1.0.0.0</Version>
         <Link SHA256="620ffc698da598e819f3c96755929aede40f26f222e4f06761623da192c5e3e9"><![CDATA[https://github.com/jngo102/DamageValues/releases/download/1.0.0.0/DamageValues.zip]]></Link>


### PR DESCRIPTION
Fix for error when installing with Scarab
Issues: https://github.com/jngo102/DamageValues/issues/3 https://github.com/jngo102/DamageValues/issues/1 https://github.com/fifty-six/Scarab/issues/111

It seems that the mod uses `../Mods/DamageValues/` directory for reading its own files, but Scarab installs the mod in `../Mods/Damage Values/` which is the `<Name>` tag, so error occurs.