### PR TITLE
Adding The Crafted Town mod to ModLinks

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4371,7 +4371,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
         <Dependencies>
             <Dependency>Satchel</Dependency>
             <Dependency>SFCore</Dependency>
-        <Dependencies/>
+        </Dependencies>
         <Repository>
             <![CDATA[https://github.com/pronoespro/PronoesProMod/]]>
         </Repository>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4361,5 +4361,25 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
             <Author>Exempt-Medic</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>Crafted Town</Name>
+        <Description>The Crafted Town adds a new location, several spell alternatives and some charm upgrades (on alpha as of now).</Description>
+        <Version>0.0.0.1</Version>
+        <Link SHA256="79CFBA053731B76F81A3E356B4298C8488160393F78729891EBBC16F8D0F4DCF">
+            <![CDATA[https://github.com/pronoespro/PronoesProMod/releases/download/hollow-knight-mod/PronoesProMod.zip]]>
+        </Link>
+        <Dependencies />
+        <Repository>
+            <![CDATA[https://github.com/pronoespro/PronoesProMod/]]>
+        </Repository>
+        <Tags>
+            <Tag>Expansion</Tag>
+            <Tag>Gameplay</Tag>
+            <Tag>Cosmetic</Tag>
+        </Tags>
+        <Authors>
+            <Author>PronoesPro</Author>
+        </Authors>
+    </Manifest>
 
 </ModLinks>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4368,7 +4368,10 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
         <Link SHA256="79CFBA053731B76F81A3E356B4298C8488160393F78729891EBBC16F8D0F4DCF">
             <![CDATA[https://github.com/pronoespro/PronoesProMod/releases/download/hollow-knight-mod/PronoesProMod.zip]]>
         </Link>
-        <Dependencies />
+        <Dependencies>
+            <Dependency>Satchel</Dependency>
+            <Dependency>SFCore</Dependency>
+        <Dependencies/>
         <Repository>
             <![CDATA[https://github.com/pronoespro/PronoesProMod/]]>
         </Repository>


### PR DESCRIPTION
This mod adds: a whole new location (the titular "Crafted Town") to hallownest; some spells you can swap with the og ones; and some upgrades to charms. I would love it if you added it to Satchel before Christmas, but I will understand if it's not possible, thank you.

Have a great day,
PronoesPro