### PR TITLE
Added HKRoomLogger

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4862,4 +4862,22 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
             <Author>Pro</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>HKRoomLogger</Name>
+        <Description>Companion mod to HKAT. Install this to use location tracking feature in that softwre.</Description>
+        <Version>1.0.8466.41315</Version>
+        <Links>
+            <Windows SHA256="6311C994520E55259ACE4D185A090D84BAF54DF962A64CDAF44B3118C5BD0CBD"><![CDATA[https://github.com/RanDumSocks/HKRoomLogger/releases/download/v1.0.8466.41315/HKRoomLogger.zip]]></Windows>
+        </Links>
+        <Dependencies />
+        <Repository>
+            <![CDATA[https://github.com/RanDumSocks/HKRoomLogger]]>
+        </Repository>
+        <Tags>
+            <Tag>Utility</Tag>
+        </Tags>
+        <Authors>
+            <Author>RanDumSocks</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4864,11 +4864,11 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     </Manifest>
     <Manifest>
         <Name>HKRoomLogger</Name>
-        <Description>Companion mod to HKAT. Install this to use location tracking feature in that softwre.</Description>
-        <Version>1.0.8466.41315</Version>
-        <Links>
-            <Windows SHA256="6311C994520E55259ACE4D185A090D84BAF54DF962A64CDAF44B3118C5BD0CBD"><![CDATA[https://github.com/RanDumSocks/HKRoomLogger/releases/download/v1.0.8466.41315/HKRoomLogger.zip]]></Windows>
-        </Links>
+        <Description>Logs scene transitions to a file. Companion mod to Windows-only software HKAT.</Description>
+        <Version>1.0.8467.33528</Version>
+        <Link SHA256="8E830E629354962B737B6D2F68E13BB109CF7D1BA32B0C03048EA44D136D0005">
+            <![CDATA[https://github.com/RanDumSocks/HKRoomLogger/releases/download/v1.0.8467.33528/HKRoomLogger.zip]]>
+        </Link>
         <Dependencies />
         <Repository>
             <![CDATA[https://github.com/RanDumSocks/HKRoomLogger]]>


### PR DESCRIPTION
Added HKRoomLogger, companion mod to [HKAT](https://github.com/RanDumSocks/HKAutoTrackerElectron).
Logs scene changes to `RoomLogger.json` in user data folder.