### PR TITLE
Added my grass randomizer mod to the mod-links.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -5348,4 +5348,31 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
             <Integration>RandoSettingsManager</Integration>
         </Integrations>
     </Manifest>
+    <Manifest>
+    <Name>Grass Randomizer</Name>
+    <Description>Supplemental randomizer mod that randomizes the grass in the world. Currently only sees grass broken with nail (c-dash does not work).</Description>
+    <Version>1.0.0.0</Version>
+	<Link SHA256="c379c665566a222148cd83ac4c4de53670eff7014bda13086f8ea25886452741">
+    <![CDATA[https://github.com/StormZillaa/HollowKnightGrassRando/releases/download/v1.0.0/GrassRandoV1.0.0.zip]]>
+    </Link>
+    <Dependencies>
+        <Dependency>RandomizerCore</Dependency>
+        <Dependency>MenuChanger</Dependency>
+        <Dependency>MapChanger</Dependency>
+        <Dependency>ItemChanger</Dependency>
+        <Dependency>Randomizer 4</Dependency>
+    </Dependencies>
+    <Repository>
+        <![CDATA[https://github.com/StormZillaa/HollowKnightGrassRando]]>
+    </Repository>
+    <Integrations>
+        <Integration>RandoSettingsManager</Integration>
+    </Integrations>
+    <Tags>
+        <Tag>Gameplay</Tag>
+    </Tags>
+    <Authors>
+        <Author>StormZillaa</Author>
+    </Authors>
+</Manifest>
 </ModLinks>


### PR DESCRIPTION
Added my Grass Randomizer mod to mod links. Uses the rando 4 and item changer mods to randomize the grass in the world and hide items in them.