### PR TITLE
Updated Crystal Machinist to fix stomper phase issues

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -2608,9 +2608,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 	<Manifest>
         <Name>Crystal Machinist</Name>
         <Description>A mod that significantly changes up the Enraged Guardian bossfight</Description>
-        <Version>1.0.0.1</Version>
-        <Link SHA256="d46133953ca07821fe75be708f244295dac6e6ec3161b1280ec8edaf63f6878d">
-            <![CDATA[https://github.com/nickc01/Crystal-Machinist/releases/download/v1.0.0.1/CrystalMachinist.zip]]>
+        <Version>2.0.0.0</Version>
+        <Link SHA256="be59cdd00ad4f777bf25eac0871daa5597fb0dfea97574d5e6e8b803dd6958b7">
+            <![CDATA[https://github.com/nickc01/Crystal-Machinist/releases/download/v2.0.0.0/CrystalMachinist.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>


### PR DESCRIPTION
Completely revamped the stomper phase. No longer is it completely random, so it should be much easier to navigate and prevent situations where it's impossible to dodge them. They also get slightly harder when on ascended and radiant difficulty, while still being possible.

Decreased stomper phase duration a bit more.

https://github.com/nickc01/Crystal-Machinist/releases/tag/v2.0.0.0