### PR TITLE
Add HKViz

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6200,4 +6200,23 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
         <Author>Ruttie</Author>
     </Authors>
   </Manifest>
+  <Manifest>
+    <Name>HKViz</Name>
+    <Description>A mod that records analytics like movement, deaths, equipped charms, abilities used and many others to allows visualizing those analytics on hkviz.olii.dev</Description>
+    <Version>1.1.0.0</Version>
+    <Link SHA256="E6B5A205E47F79F9DD2C5E0CF4A21D7359BE7B2B18A6B457D3831ACDAD1E64C4"><![CDATA[https://github.com/hkviz/hkviz-mod/releases/download/v1.1.0.0/HKViz.zip]]></Link>
+    <Dependencies/>
+    <Repository>
+        <![CDATA[https://github.com/hkviz/hkviz-mod]]>
+    </Repository>
+    <Issues>
+        <![CDATA[https://github.com/hkviz/hkviz-mod/issues]]>
+    </Issues>
+    <Tags>
+        <Tag>Utility</Tag>
+    </Tags>
+    <Authors>
+        <Author>OliverGrack</Author>
+    </Authors>
+  </Manifest>
 </ModLinks>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6205,7 +6205,12 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Description>A mod that records analytics like movement, deaths, equipped charms, abilities used and many others to allows visualizing those analytics on hkviz.olii.dev</Description>
     <Version>1.2.0.0</Version>
     <Link SHA256="D3DB76C318FC29B8930559D17EB553B759F2A55FF3C41B3886B983DD25EA9E2E"><![CDATA[https://github.com/hkviz/hkviz-mod/releases/download/v1.2.0.0/HKViz.zip]]></Link>
-    <Dependencies/>
+    <Dependencies>
+      <Dependency>HKMirror</Dependency>
+      <Dependency>MapChanger</Dependency>
+      <Dependency>Core.FsmUtil</Dependency>
+      <Dependency>Satchel</Dependency>
+    </Dependencies>
     <Repository>
         <![CDATA[https://github.com/hkviz/hkviz-mod]]>
     </Repository>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6203,7 +6203,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
   <Manifest>
     <Name>HKViz</Name>
     <Description>A mod that records analytics like movement, deaths, equipped charms, abilities used and many others to allows visualizing those analytics on hkviz.olii.dev</Description>
-    <Version>1.1.0.0</Version>
+    <Version>1.2.0.0</Version>
     <Link SHA256="D3DB76C318FC29B8930559D17EB553B759F2A55FF3C41B3886B983DD25EA9E2E"><![CDATA[https://github.com/hkviz/hkviz-mod/releases/download/v1.2.0.0/HKViz.zip]]></Link>
     <Dependencies/>
     <Repository>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6204,7 +6204,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Name>HKViz</Name>
     <Description>A mod that records analytics like movement, deaths, equipped charms, abilities used and many others to allows visualizing those analytics on hkviz.olii.dev</Description>
     <Version>1.1.0.0</Version>
-    <Link SHA256="E6B5A205E47F79F9DD2C5E0CF4A21D7359BE7B2B18A6B457D3831ACDAD1E64C4"><![CDATA[https://github.com/hkviz/hkviz-mod/releases/download/v1.1.0.0/HKViz.zip]]></Link>
+    <Link SHA256="D3DB76C318FC29B8930559D17EB553B759F2A55FF3C41B3886B983DD25EA9E2E"><![CDATA[https://github.com/hkviz/hkviz-mod/releases/download/v1.2.0.0/HKViz.zip]]></Link>
     <Dependencies/>
     <Repository>
         <![CDATA[https://github.com/hkviz/hkviz-mod]]>


### PR DESCRIPTION
Adds the HKViz mod, created by me as part of my bachelor's thesis. 

It records analytics like:
- player + enemy positions (within scenes) over time
- abilities used like nail swings, spells
- deaths + health over time
- damage taken and dealt.
- and others

Also allows can upload the recorded analytics to https://hkviz.olii.dev/ if one signs in.

Just for context some screenshots of the website:

On the start page, one can see all the gameplays / profiles / runs one has used the mod with
![image](https://github.com/hk-modding/modlinks/assets/8607040/56d5602f-c63a-42cf-933f-2f70ec28016c)

clicking on one allows a few things like:
- seeing the player movement on the map in form of a trace
![image](https://github.com/hk-modding/modlinks/assets/8607040/46e22ad6-9604-4d8a-aeb3-5de11828c0ba)
- choosing one of the variables on the left to visualize on top of the map
![image](https://github.com/hk-modding/modlinks/assets/8607040/648fd27f-38a8-4d37-9476-9b94357f7a97)

