### PR TITLE
Emergency fix for Ancient Aspid

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -2694,9 +2694,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>WeaverCore</Name>
         <Description>Core mod required for mods built with WeaverCore, such as Inferno King Grimm and Corrupted Kin</Description>
-        <Version>2.1.0.1</Version>
-        <Link SHA256="759ad0dbcba8846c4f621bd007de45e473fe707290082cfc2c17ff03e2cfc0da">
-            <![CDATA[https://github.com/nickc01/WeaverCore/releases/download/v2.1.0.1/WeaverCore.zip]]>
+        <Version>2.2.0.0</Version>
+        <Link SHA256="821514ecdcd91623fb4e4315db390ef9f3fa1cde6d853d1b455d0885be54d459">
+            <![CDATA[https://github.com/nickc01/WeaverCore/releases/download/v2.2.0.0/WeaverCore.zip]]>
         </Link>
         <Dependencies />
         <Repository>
@@ -2712,9 +2712,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>Inferno King Grimm</Name>
         <Description>A mod that significantly buffs Nightmare King Grimm into a multi-phase fight. It also includes a hard mode that can be configured on the main menu</Description>
-        <Version>4.2.2.1</Version>
-        <Link SHA256="aa512abde3bc02f76648a3909f901d389469bb120fc2272de177a28bd8adad15">
-            <![CDATA[https://github.com/nickc01/Inferno-King-Grimm/releases/download/v4.2.2.1/InfernoKingGrimm.zip]]>
+        <Version>4.2.3.0</Version>
+        <Link SHA256="be3b07402949fbfaae59c9b7e213cf0e501a11d04eaecbb6439e913f7a9a3269">
+            <![CDATA[https://github.com/nickc01/Inferno-King-Grimm/releases/download/v4.2.3.0/InfernoKingGrimm.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>
@@ -2733,9 +2733,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>Corrupted Kin</Name>
         <Description>A mod that significantly changes up the Lost Kin bossfight</Description>
-        <Version>1.3.2.0</Version>
-        <Link SHA256="2414ad7e7338a45a6b4e825bbf14f06cfe116f6cdc99387894e90ba5e2093b56">
-            <![CDATA[https://github.com/nickc01/Corrupted-Kin/releases/download/v1.3.2.0/CorruptedKin.zip]]>
+        <Version>1.4.0.0</Version>
+        <Link SHA256="7ed6f6698389dd4a854e1faa95638445219563c2e79719b200b1b689cff424be">
+            <![CDATA[https://github.com/nickc01/Corrupted-Kin/releases/download/v1.4.0.0/CorruptedKin.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>
@@ -2754,15 +2754,58 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 	<Manifest>
         <Name>Crystal Machinist</Name>
         <Description>A mod that significantly changes up the Enraged Guardian bossfight</Description>
-        <Version>2.0.1.1</Version>
-        <Link SHA256="175af74fe084759bcc0f11c9302a6497b5c30808ccacdf374cc1ff1fd56f0752">
-            <![CDATA[https://github.com/nickc01/Crystal-Machinist/releases/download/v2.0.1.1/CrystalMachinist.zip]]>
+        <Version>2.0.2.0</Version>
+        <Link SHA256="6781accf0ed64b75b62c710eff5f80842ad79d5beab02e345974881309965ae8">
+            <![CDATA[https://github.com/nickc01/Crystal-Machinist/releases/download/v2.0.2.0/CrystalMachinist.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>
         </Dependencies>
         <Repository>
             <![CDATA[https://github.com/nickc01/Crystal-Machinist/]]>
+        </Repository>
+		<Tags>
+			<Tag>Boss</Tag>
+			<Tag>Gameplay</Tag>
+		</Tags>
+		<Authors>
+			<Author>Nickc01</Author>
+		</Authors>
+    </Manifest>
+	<Manifest>
+        <Name>More Godhome Space</Name>
+        <Description>Adds a third floor to the Hall of Gods area so more modded bosses can fit</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="d248088e9474d27e3a3fcf5580043d53afde28f56f708829f537f33d2cb00a7c">
+            <![CDATA[https://github.com/nickc01/MoreGodhomeSpace/releases/download/v1.0.0.0/MoreGodhomeSpace.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>WeaverCore</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/nickc01/MoreGodhomeSpace/]]>
+        </Repository>
+		<Tags>
+			<Tag>Gameplay</Tag>
+		</Tags>
+		<Authors>
+			<Author>Nickc01</Author>
+		</Authors>
+    </Manifest>
+	<Manifest>
+        <Name>Ancient Aspid</Name>
+        <Description>A mod for Hollow Knight that adds a brand new, challenging bossfight to Kingdom's Edge</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="03debfd869714a27985b27ec139c0c23f047e016ad93abf8c28c1e146d1d26a3">
+            <![CDATA[https://github.com/nickc01/Ancient-Aspid/releases/download/v1.0.0.0/Ancient-Aspid.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>WeaverCore</Dependency>
+            <Dependency>More Godhome Space</Dependency>
+            <Dependency>SFCore</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/nickc01/Ancient-Aspid/]]>
         </Repository>
 		<Tags>
 			<Tag>Boss</Tag>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -2694,9 +2694,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>WeaverCore</Name>
         <Description>Core mod required for mods built with WeaverCore, such as Inferno King Grimm and Corrupted Kin</Description>
-        <Version>2.2.0.0</Version>
-        <Link SHA256="821514ecdcd91623fb4e4315db390ef9f3fa1cde6d853d1b455d0885be54d459">
-            <![CDATA[https://github.com/nickc01/WeaverCore/releases/download/v2.2.0.0/WeaverCore.zip]]>
+        <Version>2.2.0.1</Version>
+        <Link SHA256="390e0d7c075e4ac07d6ad51a8879437c3962936a33a3151833912bd87377beca">
+            <![CDATA[https://github.com/nickc01/WeaverCore/releases/download/v2.2.0.1/WeaverCore.zip]]>
         </Link>
         <Dependencies />
         <Repository>
@@ -2795,9 +2795,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 	<Manifest>
         <Name>Ancient Aspid</Name>
         <Description>A mod for Hollow Knight that adds a brand new, challenging bossfight to Kingdom's Edge</Description>
-        <Version>1.0.0.0</Version>
-        <Link SHA256="03debfd869714a27985b27ec139c0c23f047e016ad93abf8c28c1e146d1d26a3">
-            <![CDATA[https://github.com/nickc01/Ancient-Aspid/releases/download/v1.0.0.0/Ancient-Aspid.zip]]>
+        <Version>1.0.0.1</Version>
+        <Link SHA256="0fd13a36230d9e97b393291df7b1d8dbe6da8e322b1c744146805cf62edc8e59">
+            <![CDATA[https://github.com/nickc01/Ancient-Aspid/releases/download/v1.0.0.1/Ancient-Aspid.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -2795,9 +2795,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 	<Manifest>
         <Name>Ancient Aspid</Name>
         <Description>A mod for Hollow Knight that adds a brand new, challenging bossfight to Kingdom's Edge</Description>
-        <Version>1.0.0.1</Version>
-        <Link SHA256="0fd13a36230d9e97b393291df7b1d8dbe6da8e322b1c744146805cf62edc8e59">
-            <![CDATA[https://github.com/nickc01/Ancient-Aspid/releases/download/v1.0.0.1/Ancient-Aspid.zip]]>
+        <Version>1.0.0.2</Version>
+        <Link SHA256="99f7f6d7e5e18145f06d269eefdf512512a3c45fe8316683502aee89e8fdda9e">
+            <![CDATA[https://github.com/nickc01/Ancient-Aspid/releases/download/v1.0.0.2/Ancient-Aspid.zip]]>
         </Link>
         <Dependencies>
             <Dependency>WeaverCore</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -2774,7 +2774,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     </Manifest>
 	<Manifest>
         <Name>More Godhome Space</Name>
-        <Description>Adds a third floor to the Hall of Gods area so more modded bosses can fit</Description>
+        <Description>Adds a third floor to the Hall of Gods area so more modded bosses can be added</Description>
         <Version>1.0.0.0</Version>
         <Link SHA256="d248088e9474d27e3a3fcf5580043d53afde28f56f708829f537f33d2cb00a7c">
             <![CDATA[https://github.com/nickc01/MoreGodhomeSpace/releases/download/v1.0.0.0/MoreGodhomeSpace.zip]]>


### PR DESCRIPTION
- Fixed a bug where the aspidBossDefeated flag was set by default.
- In the WeaverCore Settings Menu, people who have the issue can reset the aspidBossDefeated flag by clicking on the "Reset Aspid Defeat Flag", and loading up the affected save file
- Changed the dreamnailable object so that it only disappears once the player picks up the charm
![Reset Aspid Defeat Flag](https://github.com/nickc01/Ancient-Aspid/assets/12601671/9c43dc6b-0d73-4dbd-97b7-87f2623cd734)