### PR TITLE
Restored HOG Randomizer

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6576,6 +6576,33 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     	</Authors>
     </Manifest>
     <Manifest>
+    	<Name>HallOfGodsRandomizer</Name>
+    	<Description>DEPRECATED - A randomizer add-on for Hall of Gods bosses.</Description>
+    	<Version>1.1.2.1</Version>
+    	<Link SHA256="2cf93185a74a911102618d3dbdc071bcfff1bc9773166f1564a28ec1cf8d3af1">
+	    <![CDATA[https://github.com/nerthul11/HallOfGodsRandomizer/releases/download/1.1.2.1/HallOfGodsRandomizer.zip]]>
+	</Link>
+	<Dependencies>
+		<Dependency>ItemChanger</Dependency>
+		<Dependency>ItemChangerDataLoader</Dependency>
+		<Dependency>KorzUtils</Dependency>
+		<Dependency>MenuChanger</Dependency>
+		<Dependency>Randomizer 4</Dependency>
+	</Dependencies>
+    	<Repository>
+	    <![CDATA[https://github.com/nerthul11/HallOfGodsRandomizer]]>
+    	</Repository>
+    	<Issues>
+	    <![CDATA[https://github.com/nerthul11/HallOfGodsRandomizer/issues]]>
+    	</Issues>
+    	<Tags>
+	    <Tag>Gameplay</Tag>
+    	</Tags>
+    	<Authors>
+	    <Author>nerthul11</Author>
+    	</Authors>
+    </Manifest>
+    <Manifest>
     	<Name>GodhomeRandomizer</Name>
     	<Description>A Randomizer add-on for Godhome elements.</Description>
     	<Version>2.1.2.1</Version>


### PR DESCRIPTION
Some people requested for it to be restored to Modlinks. For the time being, and until people are more aware of the switching to Godhome Randomizer it's probably a good idea to include it as a legacy mod and encourage the installation of the updated mod.