### PR TITLE
Make BossSync obsolete

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -7066,8 +7066,8 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     </Manifest>
 	<Manifest>
     	<Name>BossSync</Name>
-    	<Description>An extension mod for ItemSync that allows for the synchronization of bosses!</Description>
-    	<Version>1.0.1.0</Version>
+    	<Description>This mod is now obsolete as its features are implemented into another mod (MapSyncMod). Currently working on another mod to polish up some things for 112% Coop APB speedruns that will be released under the name "SpeedrunSync"</Description>
+    	<Version>This mod is obsolete, install MapSyncMod and/or SpeedrunSync instead</Version>
     	<Link SHA256="946667DB57A4BB7B4A94BBEA425216A6D2C09078374737BEDE67D43CAA6CE181">
 	    <![CDATA[https://github.com/Plutzz/BossSync/releases/download/v1.0.1.0/BossSync.zip]]>
 	</Link>
@@ -7075,6 +7075,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 		<Dependency>ItemSync</Dependency>
 		<Dependency>MenuChanger</Dependency>
 		<Dependency>Randomizer 4</Dependency>
+		<Dependency>MapChanger</Dependency>
 	</Dependencies>
     	<Repository>
 	    <![CDATA[https://github.com/Plutzz/BossSync]]>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -7067,7 +7067,7 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
 	<Manifest>
     	<Name>BossSync</Name>
     	<Description>This mod is now obsolete as its features are implemented into another mod (MapSyncMod). Currently working on another mod to polish up some things for 112% Coop APB speedruns that will be released under the name "SpeedrunSync"</Description>
-    	<Version>This mod is obsolete, install MapSyncMod and/or SpeedrunSync instead</Version>
+    	<Version>1.0.1.0</Version>
     	<Link SHA256="946667DB57A4BB7B4A94BBEA425216A6D2C09078374737BEDE67D43CAA6CE181">
 	    <![CDATA[https://github.com/Plutzz/BossSync/releases/download/v1.0.1.0/BossSync.zip]]>
 	</Link>


### PR DESCRIPTION
The download link is still in the xml file, not sure if I should remove it.