### PR TITLE
Update ModLinks.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -7206,9 +7206,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
     	<Name>GodhomeRandomizer</Name>
     	<Description>A Randomizer add-on for Godhome elements.</Description>
-    	<Version>2.2.4.5</Version>
-    	<Link SHA256="302049a2fa5d5827eaf2937306c128b906fceaceeffa9954b89d934293924e95">
-	    <![CDATA[https://github.com/nerthul11/GodhomeRandomizer/releases/download/2.2.4.5/GodhomeRandomizer.zip]]>
+    	<Version>2.2.4.6</Version>
+    	<Link SHA256="7b8b2a2f3151b0a788fa2e2f67353014c7a26bae72b76ede6c3aee1b583d0c11">
+	    <![CDATA[https://github.com/nerthul11/GodhomeRandomizer/releases/download/2.2.4.6/GodhomeRandomizer.zip]]>
 	</Link>
 	<Dependencies>
 		<Dependency>ItemChanger</Dependency>


### PR DESCRIPTION
Changelog:
- Made Unlock locations an independent setting from Statue Access. 
- Fixed Godhome transitions falsely being included in transition modes that weren't appropiate.