### PR TITLE
Update ModLinks.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -144,11 +144,11 @@
     <Name>Sunset Rad</Name>
     <Description>Modded Radiance</Description>
     <Version>1.0.0.0</Version>
-    <Link SHA256="b01a0aa751a451b914e0164bd960b36705b34e5134c8a2b3d7a163103a26ba47">
+    <Link SHA256="e723866e1f2ee2e023a7901f423cdda437a537acc8faf9e84ef7c0fc150b1bb9">
         <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/1.0.0.0/SUNSET.Rad.dll]]>
     </Link>
     <Dependencies>
-        <Dependency>Vasi</Dependency>
+        <Dependency>Vasi</Dependency>HK mirror</Dependency>
     </Dependencies>
     <Repository>
         <![CDATA[https://github.com/ROTTEN108/SunSet-Rad]]>


### PR DESCRIPTION
Fixed an issue where uninstalling moDs when the dream switch is on caused subsequent statues to fail; Installing this mod can also fix this issue caused by previous mods.