### PR TITLE
Update ModLinks.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -143,12 +143,13 @@
 <Manifest>
     <Name>Sunset Rad</Name>
     <Description>Modded Radiance</Description>
-    <Version>1.0.0.0</Version>
-    <Link SHA256="b01a0aa751a451b914e0164bd960b36705b34e5134c8a2b3d7a163103a26ba47">
-        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/1.0.0.0/SUNSET.Rad.dll]]>
+    <Version>1.0.0.1</Version>
+    <Link SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">
+        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/Sunset Last Update/SUNSET.Rad.dll]]>
     </Link>
     <Dependencies>
         <Dependency>Vasi</Dependency>
+        <Dependency>HKMirror</Dependency>
     </Dependencies>
     <Repository>
         <![CDATA[https://github.com/ROTTEN108/SunSet-Rad]]>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -144,7 +144,7 @@
     <Name>Sunset Rad</Name>
     <Description>Modded Radiance</Description>
     <Version>1.0.0.1</Version>
-    <Link SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">
+    <Link SHA256="e723866e1f2ee2e023a7901f423cdda437a537acc8faf9e84ef7c0fc150b1bb9">
         <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/1.0.0.1/SUNSET.Rad.dll]]>
     </Link>
     <Dependencies>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -145,7 +145,7 @@
     <Description>Modded Radiance</Description>
     <Version>1.0.0.1</Version>
     <Link SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">
-        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/Sunset%20Last%20Update/SUNSET.Rad.dll]]>
+        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/1.0.0.1/SUNSET.Rad.dll]]>
     </Link>
     <Dependencies>
         <Dependency>Vasi</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -145,7 +145,7 @@
     <Description>Modded Radiance</Description>
     <Version>1.0.0.1</Version>
     <Link SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">
-        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/Sunset Last Update/SUNSET.Rad.dll]]>
+        <![CDATA[https://github.com/ROTTEN108/Sunset-Rad/releases/download/Sunset%20Last%20Update/SUNSET.Rad.dll]]>
     </Link>
     <Dependencies>
         <Dependency>Vasi</Dependency>


### PR DESCRIPTION
Fixed an issue where uninstalling mod when the dream switch is on caused subsequent statues to fail; Installing this mod can also fix this issue caused by previous mods.