### PR TITLE
GrassRando Hotfix

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6813,8 +6813,8 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>Grass Randomizer</Name>
         <Description>Randomizer 4 connection that adds grass to the pool of randomized items and locations.</Description>
-        <Version>1.1.2.0</Version>
-        <Link SHA256="16C5DDD9E3803CA6C39474CA51B2AF9F165508EF62F3E5C1CE4B80BDBCF506BB"><![CDATA[https://github.com/ManicJamie/HollowKnightGrassRando/releases/download/v1.1.2/GrassRandoV2.zip]]></Link>
+        <Version>1.1.2.1</Version>
+        <Link SHA256="1CBEE53610A872BE04AE55D74A91D68027D5592F849506BC62C3D85C5A2FC18B"><![CDATA[https://github.com/ManicJamie/HollowKnightGrassRando/releases/download/v1.1.2.1/GrassRandoV2.zip]]></Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>
             <Dependency>GrassCore</Dependency>


### PR DESCRIPTION
Disables RMM LogicDef integration to prevent Explosions & Fire