### PR TITLE
BWR bump

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1081,9 +1081,9 @@ All with an incredible new soundtrack!</Description>
     <Manifest>
         <Name>Breakable Wall Randomizer</Name>
         <Description>A Hollow Knight Randomizer add-on for breakable walls.</Description>
-        <Version>3.0.2.6</Version>
-        <Link SHA256="A549B012A9D472CDD2665BCDC4A8E0CC8AE33C2D47C62594961F1F89409DAA9D">
-            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/3.0.2.6/BreakableWallRandomizer.zip]]>
+        <Version>3.0.2.7</Version>
+        <Link SHA256="06A91C732262E70B2B26330B6770EFC7309127D2C5DB347E4BF670F1DA30A09D">
+            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/3.0.2.7/BreakableWallRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>


### PR DESCRIPTION
Changelog:
-Fixed a bug when a Split Group wouldn't be initialized if no other item was on said group.
-Added grouping for Wall Groups and split them into Wall/Plank/Dive groups.
-Logic fixes for Isma's Grove Plank and Fungus3_39 (Moss Prophet room).