### PR TITLE
Update CarThingMod in ModLinks.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -7358,9 +7358,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
 	    <Name>CarThingMod</Name>
 	    <Description>Throws a car everytime the player swings their nail</Description>
-	    <Version>1.2.6.4</Version>
-	    <Link SHA256="A6B95550C52AAAB61DE4983C30FF107B6F09D5C5F3C08E4E5670465441A32732">
-	            <![CDATA[https://github.com/Foxyrobo/CarThingMod/releases/download/1.2.6.4/CarThingMod.zip]]>
+	    <Version>1.2.8.1</Version>
+	    <Link SHA256="F8A5848A6DCA2DA10AA50E76201CC029A788EC57ED9662E560632A3ADC2F5405">
+	            <![CDATA[https://github.com/Foxyrobo/CarThingMod/releases/download/1.2.8.1/CarThingMod.zip]]>
 	    </Link>
 	    <Dependencies>
 	        <Dependency>Satchel</Dependency>


### PR DESCRIPTION
Updates CarThingMod to version 1.2.8.1 to fix bugs from versions 1.2.6.4 and 1.2.7.7