### PR TITLE
AccessRando hotfix & BWR bump

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1096,9 +1096,9 @@ All with an incredible new soundtrack!</Description>
     <Manifest>
         <Name>Breakable Wall Randomizer</Name>
         <Description>A Hollow Knight Randomizer add-on for breakable walls.</Description>
-        <Version>3.0.4.0</Version>
-        <Link SHA256="2B3ED0DCAF39E791B9742B92509259995928885E9E833B347223A2F2B6646E70">
-            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/3.0.4.0/BreakableWallRandomizer.zip]]>
+        <Version>3.0.4.1</Version>
+        <Link SHA256="D27323AF4216B5C75F302459FD2B5042986D9BE1213023492D8BBC3EE695279D">
+            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/3.0.4.1/BreakableWallRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>
@@ -7677,9 +7677,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
     	<Name>AccessRandomizer</Name>
     	<Description>A randomizer add-on for miscellaneous access checks.</Description>
-    	<Version>1.3.0.0</Version>
-    	<Link SHA256="495A45C61915D2114696A0288A3639D0C92F19D9565F03F214631EB9DD11658D">
-	    <![CDATA[https://github.com/nerthul11/AccessRandomizer/releases/download/1.3.0.0/AccessRandomizer.zip]]>
+    	<Version>1.3.0.1</Version>
+    	<Link SHA256="6118326538F11B9F031162775DB589F37C7768A0B803FF409D12148666D844A9">
+	    <![CDATA[https://github.com/nerthul11/AccessRandomizer/releases/download/1.3.0.1/AccessRandomizer.zip]]>
 	</Link>
 	<Dependencies>
 		<Dependency>ItemChanger</Dependency>


### PR DESCRIPTION
Changelog:
- Patched an issue in the nomenclature change from RESPECT -> Mantis_Respect with the MoreDoors interop.
- NPCKeys is now called CustomKeys and has an individual setting for each key.
- Bardoon's Butt & other wall logic changes.