### PR TITLE
Access rando hotfix's hotfix

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -7677,9 +7677,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
     	<Name>AccessRandomizer</Name>
     	<Description>A randomizer add-on for miscellaneous access checks.</Description>
-    	<Version>1.3.0.1</Version>
-    	<Link SHA256="6118326538F11B9F031162775DB589F37C7768A0B803FF409D12148666D844A9">
-	    <![CDATA[https://github.com/nerthul11/AccessRandomizer/releases/download/1.3.0.1/AccessRandomizer.zip]]>
+    	<Version>1.3.0.2</Version>
+    	<Link SHA256="107AB8BEB8F3A82BE326AE4DB5175FB223E1E6B401C77B476F0DBE92FE20C29E">
+	    <![CDATA[https://github.com/nerthul11/AccessRandomizer/releases/download/1.3.0.2/AccessRandomizer.zip]]>
 	</Link>
 	<Dependencies>
 		<Dependency>ItemChanger</Dependency>


### PR DESCRIPTION
Changelog:
- Fixes a glitch that caused Lemm's door to stay closed with the Relic Key.