### PR TITLE
Update CustomKnightSuperAnimationAddon

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4714,9 +4714,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>CustomKnightSuperAnimationAddon</Name>
         <Description>Allows inserting custom spritesheets for animations. To export spritesheets, use https://github.com/RedFrog6002/sseadv</Description>
-        <Version>1.0.0.1</Version>
-        <Link SHA256="F041694E6046A4B266901F128C1F10B8F093273CDEA12E068F0856A73222BE58">
-            <![CDATA[https://github.com/RedFrog6002/CustomKnightSuperAnimationAddon/releases/download/v1.0.0.1/CustomKnightSuperAnimationAddon.zip]]>
+        <Version>1.0.0.2</Version>
+        <Link SHA256="1E44E6A007E8C16545ADDDA64F7F1E524DD83EBA04D72D2A63E140B7FB5F117D">
+            <![CDATA[https://github.com/dplochcoder/CustomKnightSuperAnimationAddon/releases/download/v1.0.0.2/CustomKnightSuperAnimationAddon.zip]]>
         </Link>
         <Dependencies>
             <Dependency>FrogCore</Dependency>


### PR DESCRIPTION
Update CustomKnightSuperAnimationAddon.

This is not my mod (it belongs to https://github.com/RedFrog6002), but the mod owner has not responded to multiple requests for release or release privileges for nearly one year, despite the relevant bug fix(es) being PR'd and merged already.  These fixes allow other users to use the Ori/Sein skin, as well as provide expanded animation images in general for game objects other than the Knight.

This release is built from a fork of the main repo where the only difference is the change in version number: https://github.com/RedFrog6002/CustomKnightSuperAnimationAddon/commit/53c02dfc0a8ce294f843d9b1b91f2219dad9d53e