### PR TITLE
Add new mod: Silksong Healing

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -8939,4 +8939,24 @@ Enjoy!</Description>
             <Author>Adam Jiwa</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>Silksong Healing</Name>
+        <Description>Adds a charm called Soulburst, which allows players to instantly heal 3 masks when they have 99 soul, similar to Silksong</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256 ="B1C63D71B4D39758EB73CE74A9892B946E0F07519FF0ECC353099E1497E555BC">
+            <![CDATA[https://github.com/hien-ngo29/SilksongHealing/releases/download/v1.0.0/SilksongHealing.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>SFCore</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/hien-ngo29/SilksongHealing]]>
+        </Repository>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+        <Authors>
+            <Author>Hien Ngo</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
Add a charm called Soulburst, which allows players to instantly heal 3 masks when they have 99 SOUL, similar to Silksong