### PR TITLE
Add ConfigurableMaskDamage

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9205,4 +9205,22 @@ Enjoy!</Description>
             <Author>cometcake575</Author>
         </Authors>
     </Manifest>
+      <Manifest>
+        <Name>ConfigurableMaskDamage</Name>
+        <Description>Changes the amount of damage dealt to the knight</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="cbef978a7e71966f91399ed122ee598ce613f2f8a0cff7cfe10f4f530e98c204">
+            <![CDATA[https://github.com/F1NS3N/ConfigurableMaskDamage/releases/download/ConfigurableMaskDamage-v1.0.0/ConfigurableMaskDamage.zip]]>
+        </Link>
+        <Dependencies />
+        <Repository>
+            <![CDATA[https://github.com/F1NS3N/ConfigurableMaskDamage]]> 
+        </Repository>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+        <Authors>
+            <Author>FIN</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
A mod that allows you to customize the damage inflicted on the knight. Useful for some community challenges (for example Double Damage P5AB)

*Fixed problems with saving files