### PR TITLE
Update Smart Nail

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9015,9 +9015,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Smart Nail</Name>
         <Description>Qol mod for RandoPlus,which auto-upgrades your nail in Godhome and in dream bosses fights.Doesn't work with combat or curse rando.</Description>
-        <Version>1.3.0.0</Version>
-        <Link SHA256 ="D7E46371D52DF323184D334BC845545367E1A044A52F3475D0C83DC15ABD016C">
-            <![CDATA[https://github.com/Roma-337/SmartNail/releases/download/v1.3.0/SmartNail.zip]]>
+        <Version>1.3.5.0</Version>
+        <Link SHA256 ="1D6C3522E935523E65E4DE5BF5F671592D947B9C5550A395F07023DFA176B6E7">
+            <![CDATA[https://github.com/Roma-337/SmartNail/releases/download/v1.3.5/SmartNail.zip]]>
         </Link>
         <Dependencies>
             <Dependency>ItemChanger</Dependency>


### PR DESCRIPTION
Fixed a bug that deleted upgrades.Now base stats are saved without relying on onsavegame