### PR TITLE
Updated Architect to 1.2.1.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9212,9 +9212,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.2.1.3</Version>
-        <Link SHA256="40adde4e1196b8fa5e963ec990c171ecd17c2f2fae779ea8b81463accd836557">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.2.1.3/Architect.zip]]>
+        <Version>1.2.1.4</Version>
+        <Link SHA256="9c6dea66d4f48333b7f4ed6424452b72da7d1dbc555fa465755fe483b32bdd8b">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.2.1.4/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added the Energy Orb and Radiant Orb, two custom objects that deal damage and cannot be hit with the nail to pogo off of them. The Energy Orb deals 1 damage and the Radiant Orb instantly kills the player. Both have the same movement configuration options as the sawblade.
- Removed the blur from the trigger zone.
- Added Binding objects, which allow you to restrict the player's abilities. These include the 4 Pantheon bindings, bindings for the 3 spells and focus, bindings for movement abilities, bindings for the dream nail and dreamgate and bindings for nail arts.