### PR TITLE
Updated Architect to 1.3.2.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.1.2</Version>
-        <Link SHA256="81ad3e4ada0d4702efc114b47692a18b1b287bb52271ab850d661919e20541cb">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.2/Architect.zip]]>
+        <Version>1.3.2.0</Version>
+        <Link SHA256="46f9f86d891cef1ffc6dab1d27d3f1e04b001723f4fbfa8cdd78cca044a7e2f9">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.2.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.0.1</Version>
-        <Link SHA256="1471b6f1ef7c85dc22b5728f67614f7ef36f13915eec4f86f6d8a5dfac978dc6">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.0.1/Architect.zip]]>
+        <Version>1.3.1.0</Version>
+        <Link SHA256="4b8489dcdc01f074b3e60b91853dd1feef7dadda85064184296f7b40322c9075">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.2.0</Version>
-        <Link SHA256="46f9f86d891cef1ffc6dab1d27d3f1e04b001723f4fbfa8cdd78cca044a7e2f9">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.2.0/Architect.zip]]>
+        <Version>1.3.2.1</Version>
+        <Link SHA256="1ebf39404b7ff8a091c376001f33a308fc77c6c329e5f873517a9f5003a66073">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.2.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.0.0</Version>
-        <Link SHA256="ff0cf5cf39da66104d8cac2d3cd3dbeb4077d7eaf7fda3f5cf384acfd704c313">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.0.0/Architect.zip]]>
+        <Version>1.3.0.1</Version>
+        <Link SHA256="1471b6f1ef7c85dc22b5728f67614f7ef36f13915eec4f86f6d8a5dfac978dc6">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.0.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.2.2.0</Version>
-        <Link SHA256="f2e37e7ae2e8dee524eac67beaae072b84afff2fa517e794a4d0d5e0e9e689ed">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.2.2.0/Architect.zip]]>
+        <Version>1.2.2.1</Version>
+        <Link SHA256="0a7e1973910df81edcea44b05543e488bf62fab2f5bb7e5dd7a5602d123a1e2a">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.2.2.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.1.1</Version>
-        <Link SHA256="c034ddaeb35bf8ec7c81d3d3b6c05ae9d325b26f653efe15fca5cf550f77658c">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.1/Architect.zip]]>
+        <Version>1.3.1.2</Version>
+        <Link SHA256="81ad3e4ada0d4702efc114b47692a18b1b287bb52271ab850d661919e20541cb">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.2.2.1</Version>
-        <Link SHA256="0a7e1973910df81edcea44b05543e488bf62fab2f5bb7e5dd7a5602d123a1e2a">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.2.2.1/Architect.zip]]>
+        <Version>1.3.0.0</Version>
+        <Link SHA256="ff0cf5cf39da66104d8cac2d3cd3dbeb4077d7eaf7fda3f5cf384acfd704c313">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.0.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9233,9 +9233,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.3.1.0</Version>
-        <Link SHA256="4b8489dcdc01f074b3e60b91853dd1feef7dadda85064184296f7b40322c9075">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.0/Architect.zip]]>
+        <Version>1.3.1.1</Version>
+        <Link SHA256="c034ddaeb35bf8ec7c81d3d3b6c05ae9d325b26f653efe15fca5cf550f77658c">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.3.1.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed a slight offset on the Elder Baldur.
- Hazards are now shown in reverse order to put the more useful late-game hazards at the start of the list.
- Added the White Thorns, which can be moved in the same way as sawblades and damage orbs and can be rotated 360 degrees.
- A new category called "Room Edits" has been created with 4 new items to disable vanilla objects, all of which can also be enabled/disabled with events to toggle their effects:
  - Clear Room: Removes vanilla objects from the room, with some configuration settings to keep certain objects such as background, transition points, NPCs, music, camera locks etc.
  - Remove Transition Point: Removes the nearest transition point to the object
  - Remove Hazard Respawn Point: Removes the nearest Hazard Respawn Point to the object
  - Object Remover: Removes an object at a specific path from the room
    - This is more complicated to use, as you need to know the object's internal name and path, but can be used to remove specific, individual objects instead of full categories
- The Teleport Point and Hazard Respawn Point have been moved to the "Room Edits" category
- The Hazard Respawn Point now has a config option to disable it activating upon collision, and a trigger, "setspawn", to trigger it, meaning it can now be triggered from a distance
- A new config option has been added, Visible, which can be used to make objects invisible
- Fixed capital letters in trigger names causing errors