### PR TITLE
Add HK_QoLTeleportKit

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9324,4 +9324,24 @@ Enjoy!</Description>
             <Author>kon4ino</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>HK_QoLTeleportKit</Name>
+        <Description>QoL Teleport Kit is a Hollow Knight mod that adds a convenient teleportation system.</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="0df5edac491b29b0d51f1fdd1255c4a6d33e40baef1b0be7bcc1ff4ab911d275">
+            <![CDATA[https://github.com/NightFuryoOo/HK_QoLTeleportKit/releases/download/v1.0.0.0/QoLTeleportKit.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency></Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/NightFuryoOo/HK_QoLTeleportKit]]> 
+        </Repository>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+        <Authors>
+            <Author>NightFuryo3o</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
QoL Teleport Kit is a Hollow Knight mod that adds a convenient teleportation system.

Installation Ensure you have ModInstaller for Hollow Knight

Download the latest version from Releases section

Place the .dll file in the game's Mods folder

Controls Action Default Key Open/close menu - F6 Save position - R Teleport to saved position - T Previous page - Q Next page - E Number input - 0-9 Confirm teleport - Enter Clear input - Backspace Close menu - Esc All keys can be rebound in-game (hold Ctrl and press the desired key)

Menu Pages Page 1: Hall of Gods (Floor 1) Teleport to bosses on Hall of Gods floor 1 (1-18)

Page 2: Hall of Gods (Floor 2) Teleport to bosses on Hall of Gods floor 2 (19-36)

Page 3: Pantheons Teleport to Pantheon entries and bench (37-43)

Page 4: Path of Pain Teleport to Path of Pain segments (44-56)

Technical Notes Automatically unlocks Godhome if not visited yet

Custom waypoints reset when changing scenes

Detailed logs saved to QoLTeleportKit.log

Compatibility Tested on Hollow Knight version 1.5.78.11833. Compatible with most other mods.