### PR TITLE
Updated Architect to 1.5.3.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9247,9 +9247,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.5.1.2</Version>
-        <Link SHA256="9b65fa87cb0174593a9fb1b8c58f4497862fa728dd729ad7d361b7ce62904cfe">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.5.1.2/Architect.zip]]>
+        <Version>1.5.2.0</Version>
+        <Link SHA256="7f2099c3e6d73184845c4d3c4813cd4206f36a3376f2181584ece8d989f7ca35">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.5.2.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9247,9 +9247,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.5.2.0</Version>
-        <Link SHA256="7f2099c3e6d73184845c4d3c4813cd4206f36a3376f2181584ece8d989f7ca35">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.5.2.0/Architect.zip]]>
+        <Version>1.5.3.0</Version>
+        <Link SHA256="8a520d9ddb8dbf9a9bdd5743b537b0bcd1a4ce92a6c17d710d6cffc6299882d5">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.5.3.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added Key Listener, to listen for specific key presses
- Rotation can now be at any angle, not just whole numbers
- Added the Unsafe Rotations keybind to rotate any object at any angle, rather than predefined rotations
- Coloured objects can now be solid or hazard colliders
- Fixed an issue where players needed to have the edit toggle enabled in order for levels to refresh properly over multiplayer
- Added the Watcher Knights
- The Trigger Zone can now be set to use custom width and height values
- Added the Relay, which triggers an "OnCall" event when it runs the "call" trigger