### PR TITLE
Updated Architect to 1.7.0.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9269,9 +9269,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.6.1.2</Version>
-        <Link SHA256="6a5b9a3a4362fc2764eca5d68b11baab182383f211d2641087f51c17e26bedcd">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.6.1.2/Architect.zip]]>
+        <Version>1.7.0.0</Version>
+        <Link SHA256="90210bdd3e6501cd6c668d0718ce8eaf745600217a46bfc865832784cff5c723">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.7.0.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9277,6 +9277,7 @@ Enjoy!</Description>
             <Dependency>Satchel</Dependency>
             <Dependency>MagicUI</Dependency>
             <Dependency>SFCore</Dependency>
+            <Dependency>Scattered and Lost</Dependency>
         </Dependencies>
         <Repository>
             <![CDATA[https://github.com/cometcake575/Architect]]>


### PR DESCRIPTION
- Added the Player Listener
- Added the Shade Gate
- Added the Celeste Crystals when using the Scattered and Lost mod
- Added an "ID" option to the Relay, as well as "enable_relay" and "disable_relay" triggers.
  - If you give the Relay an ID, its enabled/disabled state will be shared across rooms and will persist between game loads (unless you configure it to reset upon sitting at a bunch), allowing for persistent data storage
- Fixed co-op level editing not working when using a standalone server