### PR TITLE
Updated Architect to 1.8.5.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9270,9 +9270,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.8.4.0</Version>
-        <Link SHA256="b3915afbc5865bdafa05264e8be2b9566835d73f24e9126857b7b638f4624601">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.4.0/Architect.zip]]>
+        <Version>1.8.5.0</Version>
+        <Link SHA256="876d869621d2fb58a235d3c6bc438489c1021c2682962f1184364b337b82d1a9">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.5.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Removed the star icon from empty objects
- Favourites now appear in the category in the order you added them, instead of being locked to a specific order
- Added Prefabs
  - Press the enter key to create a Prefab with your currently selected object (You can rebind this key in the config)
  - Prefabs are selectable in the "Prefabs" category and store all settings
  - You can delete a Prefab with the "X" button which appears next to the icon in the category