### PR TITLE
Added OWO_HollowKnight mod

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9464,23 +9464,22 @@ Enjoy!</Description>
         </Authors>
     </Manifest>
     <Manifest>
-    <Name>OWO_HollowKnight</Name>
-    <Description>A mod that allows the integration of OWO Skin haptic device with HK</Description>
-    <Version>1.0.0.0</Version>
-    <Link SHA256="c40041b5733d3fce3f54cbbfddad63075b34999edebe550aa0970194de9ebe96">
-        <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight/releases/download/1.0.0/OWO_HollowKnight.zip]]></Link>
-    <Dependencies>
-            <Dependency>Satchel</Dependency>
-    </Dependencies>
-    <Repository>
-        <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight]]>
-    </Repository>
-    <Tags>
-        <Tag>Haptic</Tag>
-        <Tag>Utility</Tag>
-    </Tags>
-    <Authors>
-        <Author>OWO Game</Author>
-    </Authors>
-</Manifest>
+        <Name>OWO_HollowKnight</Name>
+        <Description>A mod that allows the integration of OWO Skin haptic device with HK</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="c40041b5733d3fce3f54cbbfddad63075b34999edebe550aa0970194de9ebe96">
+            <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight/releases/download/1.0.0/OWO_HollowKnight.zip]]></Link>
+        <Dependencies>
+                <Dependency>Satchel</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight]]>
+        </Repository>
+        <Tags>
+            <Tag>Utility</Tag>
+        </Tags>
+        <Authors>
+            <Author>OWO Game</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9463,4 +9463,24 @@ Enjoy!</Description>
             <Author>FIN</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+    <Name>OWO_HollowKnight</Name>
+    <Description>A mod that allows the integration of OWO Skin haptic device with HK</Description>
+    <Version>1.0.0.0</Version>
+    <Link SHA256="c40041b5733d3fce3f54cbbfddad63075b34999edebe550aa0970194de9ebe96">
+        <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight/releases/download/1.0.0/OWO_HollowKnight.zip]]></Link>
+    <Dependencies>
+            <Dependency>Satchel</Dependency>
+    </Dependencies>
+    <Repository>
+        <![CDATA[https://github.com/OWODevelopers/OWO_HollowKnight]]>
+    </Repository>
+    <Tags>
+        <Tag>Haptic</Tag>
+        <Tag>Utility</Tag>
+    </Tags>
+    <Authors>
+        <Author>OWO Game</Author>
+    </Authors>
+</Manifest>
 </ModLinks>


### PR DESCRIPTION
This is a mod that allows using the haptic suit made by OWO Game with Hollow Knight, therefore you can feel the attacks, abilities and damages of our little hero.