### PR TITLE
Updated Architect to 1.8.5.4

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9270,9 +9270,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.8.5.3</Version>
-        <Link SHA256="9da1cadd3da1a14bf74264fc115597db1af7c7d37de1cb5664d9eacf461f3f7f">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.5.3/Architect.zip]]>
+        <Version>1.8.5.4</Version>
+        <Link SHA256="102d637d50857c40d843a6bfa8d76c6118537c1a6f030f0d85479ca01fd95025">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.5.4/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed a glitch where Rotation over Time wasn't reversed when moving objects moved backwards