### PR TITLE
Updated Architect to 1.8.6.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9270,9 +9270,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.8.6.0</Version>
-        <Link SHA256="b6e6111323c5bd6d990cf7d6aedfc2f5b9c9143897e5d1af67e78f1e5ef6fd01">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.6.0/Architect.zip]]>
+        <Version>1.8.6.1</Version>
+        <Link SHA256="4bbdb97a433fc44b94212555636841c7005b9edff6c1a35905bc01d83fbd83ca">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.6.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added text to indicate that a level has been successfully downloaded/uploaded/deleted using the level sharer to avoid confusion