### PR TITLE
BWR bump

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1336,9 +1336,9 @@ All with an incredible new soundtrack!</Description>
     <Manifest>
         <Name>Breakable Wall Randomizer</Name>
         <Description>A Hollow Knight Randomizer add-on for breakable walls.</Description>
-        <Version>4.0.0.6</Version>
-        <Link SHA256="CD12F40F9ECE256A0466C6E70289444141CC84682F10F27254FB817F85F0B40B">
-            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.0.0.6/BreakableWallRandomizer.zip]]>
+        <Version>4.0.1.0</Version>
+        <Link SHA256="2EB9EDD026E240EADCB49216A67D3AE25141DAB0E7E22FB3106FC4686460DED2">
+            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.0.1.0/BreakableWallRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>


### PR DESCRIPTION
Changelog:
- Renamed Wall-Deepnest_Springs_Grub to Wall-Nosk_Entrance
- Added pins for White Palace walls if using Additional Maps. Godhome map doesn't really use the Workshop for those walls.
- Logic fixes for Abyss_19, Cliffs_01, Deepnest_01, RestingGrounds_10, Waterways_07, Ruins1_32 walls and Bretta Key interop.