### PR TITLE
Updated Architect to 1.9.1.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.8.8.2</Version>
-        <Link SHA256="3d2c4541f4f5637b93e9f84ef739af2a699fa0afa12c0b7b3262892eeee3b34a">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.8.8.2/Architect.zip]]>
+        <Version>1.9.0.0</Version>
+        <Link SHA256="ed196aac817a7a5cb603071cb434f86c73457bf1c66e4a3d865e18e5d281003d">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.9.0.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.9.0.0</Version>
-        <Link SHA256="ed196aac817a7a5cb603071cb434f86c73457bf1c66e4a3d865e18e5d281003d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.9.0.0/Architect.zip]]>
+        <Version>1.9.1.0</Version>
+        <Link SHA256="f145a08412715d6f012e968a7aab4553795424aeaf7bf719fdcd6f7182e168f1">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.9.1.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added the Solid Remover, which can remove any object with collision (useful for removing platforms)
- Added the Small Lever object
- Added the Wide Platform object, a wide, solid platform
- Added the Falling Crystals object from the Crystal Peak
  - The crystals can also be configured to deal damage on collision, this changes their colour
- Moving Platforms can now be configured to not stick the player to them, requiring the player to move with the platform
- Relays can now be configured to broadcast events over multiplayer
  - This means you can have an event in one player's game trigger an action in another
- The Trigger Zone now has 4 modes - Player, Enemy, Nail Swing and Zote Head, to detect different things (by default it will detect the player)
- Added a Dive Ground object, ground that can be broken using Desolate Dive/Descending Dark
- Fixed a glitch where prefabs would be reset if you added a new prefab after reloading the game