### PR TITLE
Updated Architect to 1.10.0.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.0.0</Version>
-        <Link SHA256="96aa8f66238485595ff26afff09d5ec8573244a3669cdab99df965f83275b0ab">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.0.0/Architect.zip]]>
+        <Version>1.10.0.1</Version>
+        <Link SHA256="16bf725fb9e6dd5d03af79a318115ded869acf56162d4176068fca8be406b4f5">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.0.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where the player froze when colliding with the binoculars