### PR TITLE
Updated Architect to 1.10.1.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.0.2</Version>
-        <Link SHA256="66624fdeee7a1930de86f1069cd76d51c130fe9394e99d2f85cbaa3fac016408">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.0.2/Architect.zip]]>
+        <Version>1.10.0.3</Version>
+        <Link SHA256="cf043332da95cb64788813fade0d991996f4e343889f7b48f24f05a78b03a7e6">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.0.3/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.0.3</Version>
-        <Link SHA256="cf043332da95cb64788813fade0d991996f4e343889f7b48f24f05a78b03a7e6">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.0.3/Architect.zip]]>
+        <Version>1.10.1.0</Version>
+        <Link SHA256="e14130026975cbd7758bf77f5f698e971339e444bb8da517d980bc2fad3539f5">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.1.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.1.0</Version>
-        <Link SHA256="e14130026975cbd7758bf77f5f698e971339e444bb8da517d980bc2fad3539f5">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.1.0/Architect.zip]]>
+        <Version>1.10.1.1</Version>
+        <Link SHA256="6156b2bc89ba99bb6f884da1bbb82c785af726e164841412400ba295a885b60a">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.1.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed the Trigger Zone exit event not working with the mode setting
- Added a respawn_egg trigger to the Jelly Egg Bomb
- Fixed an issue where the Text Display still showed text when disabled