### PR TITLE
Updated Architect to 1.10.2.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9304,9 +9304,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.2.0</Version>
-        <Link SHA256="dc05c11c226d489ea91779dafb78bf2e39ca7bfa1dd9e7a075d57a572ce4994d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.2.0/Architect.zip]]>
+        <Version>1.10.2.1</Version>
+        <Link SHA256="b177cb426cb5d018fd1de72150ba1d3bc03ddb91cff88c63416c3b9717bebeea">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.2.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Made the Object Mover's "Set" mode relative to the Object Mover
- Fixed the Object Mover's "Set" mode making the object's scale 0