### PR TITLE
Updated Architect to 1.10.5.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9338,9 +9338,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.4.1</Version>
-        <Link SHA256="84dbcbad3aafe6c77885bcd2157e3071642239126db6d570bd34c691d3ea5748">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.4.1/Architect.zip]]>
+        <Version>1.10.5.0</Version>
+        <Link SHA256="6810f2e69a5d629f1d5e9800caf36e53ae6f07ba9adf93db9f64235fb458435c">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.5.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added undo and redo keybinds (Z and Y by default)
  - Undo history is stored as long as you are in the same room
- Rotated benches now tilt the player
- Added a "Remove Other" setting to the Room Clearer to avoid confusion
  - This means that now by disabling every setting except one, you *can* disable that specific set of objects, whilst before this would also disable any objects not in a category
- All Room Clearer settings now display whether they are True/False by default to avoid confusion about what their default values are
- The "Unset" label in the configuration has been renamed to "Default"
- Added 2 Cloud objects from Godhome to Decorations
- Added a Godhome XL platform
- Added a Godhome Tiles platform
- Prefabs can now be saved when paused
- Disabled the rotate, scale and flip keybinds when paused
- Added Massive Moss Charger
- Fixed an issue where the Elder Baldur did not scale properly