### PR TITLE
Updated Architect to 1.10.9.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9354,9 +9354,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.8.1</Version>
-        <Link SHA256="0f11f92837b4a2820d827304fce0bab41bc33a95def04b99408f62a035e30889">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.8.1/Architect.zip]]>
+        <Version>1.10.9.0</Version>
+        <Link SHA256="3d6b6b6ed053375b4ff642a3a47f57c514e83f391d1a123a0de999197694f19c">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.9.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- You can now delete many objects at once by selecting them with the Drag tool, then clicking with the Erase tool.
- Benches and Hazard Respawn Points now function when placed inside of edit mode.
- Messages are now displayed when the Zote Trophy is collected, making it good for multiplayer racing.
- Added a configuration setting to benches to stop them from setting the player's spawn point (similar to benches in the Pantheons)
- If a respawn point is invalid (e.g. if you deleted the last respawn point or bench you had set), the game will now default to the first hazard respawn point it can find in the room, instead of freezing the player and breaking the game.
- When switching to another tool from the Drag tool, your selection is now properly cleared (aside from when switching to the Eraser) and dragging now only works with the tool selected.
- Fixed an issue where you could take damage in edit mode by walking into a hazard right after taking damage and switching mode.