### PR TITLE
Updated Architect to 1.10.9.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9354,9 +9354,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.10.9.1</Version>
-        <Link SHA256="557ed7827bc4b044e933a580fef4a6a6100ec3d54b75fd30b4c1d26305daab75">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.9.1/Architect.zip]]>
+        <Version>1.10.9.2</Version>
+        <Link SHA256="afcafa60d1e39310d61ff0c759e0a878f00b1768720e37a0932955963be10acc">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.10.9.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Shardmite can now be rotated
- Eraser properly deselects objects
- Added a Massive Moss Charger zone config setting
- Removed the random Massive Moss Charger underground hitbox
- Massive Moss Charger Emerge Offset config