### PR TITLE
Updated Architect to 1.11.0.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9403,9 +9403,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.11.0.1</Version>
-        <Link SHA256="33da4889b69e1e2fc3e102348f8901966a974655bb107fcef4d6ca8195d86c9a">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.0.1/Architect.zip]]>
+        <Version>1.11.0.2</Version>
+        <Link SHA256="5d36acb1ae5e43c6e3fd4b683e76f9efb2fe80bdbce113c4b2be7628a3f1cf3b">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.0.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed broken City of Tears lever
- Fixed broken bench preview scale
- Negative values for conveyor belt speeds now flip the conveyor belt
- Fixed an issue where toggling edit mode whilst standing on a conveyor belt caused the player to keep moving