### PR TITLE
Updated Architect to 1.11.1.3

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9425,7 +9425,7 @@ Enjoy!</Description>
     </Manifest>
     <Manifest>
         <Name>Architect</Name>
-        <Description>A level editor mod allowing you to add or remove platforms, enemies and more with an in-game level editor and level sharer.</Description>
+        <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
         <Version>1.11.1.3</Version>
         <Link SHA256="5a70e763e03a8f9ae5288c0fce4e8876b07e4ceb5a9033da9908d7851afc50b0">
             <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.3/Architect.zip]]>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9425,7 +9425,7 @@ Enjoy!</Description>
     </Manifest>
     <Manifest>
         <Name>Architect</Name>
-        <Description>A level editor mod allowing you to add or remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
+        <Description>A level editor mod allowing you to add or remove platforms, enemies and more with an in-game level editor and level sharer.</Description>
         <Version>1.11.1.3</Version>
         <Link SHA256="5a70e763e03a8f9ae5288c0fce4e8876b07e4ceb5a9033da9908d7851afc50b0">
             <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.3/Architect.zip]]>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9425,10 +9425,10 @@ Enjoy!</Description>
     </Manifest>
     <Manifest>
         <Name>Architect</Name>
-        <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.11.1.0</Version>
-        <Link SHA256="afb1b437b5cffc316d669a6dfc884ec7ac04521775f2cad41c474eb9ea4ee93d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.0/Architect.zip]]>
+        <Description>A level editor mod allowing you to add or remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
+        <Version>1.11.1.1</Version>
+        <Link SHA256="b0cf6820592b5af49222847624e31f237e35ecc34eaa76dda40e2a6cbca9f29b">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9426,9 +9426,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A mod to add/remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.11.0.5</Version>
-        <Link SHA256="db60bdf832c5a26d90b1f5f2817fa09424f57e95ac1c114dfd5c08448e8dc65d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.0.5/Architect.zip]]>
+        <Version>1.11.1.0</Version>
+        <Link SHA256="afb1b437b5cffc316d669a6dfc884ec7ac04521775f2cad41c474eb9ea4ee93d">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9426,9 +9426,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod allowing you to add or remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.11.1.1</Version>
-        <Link SHA256="b0cf6820592b5af49222847624e31f237e35ecc34eaa76dda40e2a6cbca9f29b">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.1/Architect.zip]]>
+        <Version>1.11.1.2</Version>
+        <Link SHA256="3d211053d8a9f6a143651e9ae86204221c77af542056866fd73d213777c8c387">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9426,9 +9426,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod allowing you to add or remove platforms, enemies and more to change areas in the game with an in-game level editor and level sharer.</Description>
-        <Version>1.11.1.2</Version>
-        <Link SHA256="3d211053d8a9f6a143651e9ae86204221c77af542056866fd73d213777c8c387">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.2/Architect.zip]]>
+        <Version>1.11.1.3</Version>
+        <Link SHA256="5a70e763e03a8f9ae5288c0fce4e8876b07e4ceb5a9033da9908d7851afc50b0">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.11.1.3/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added a "Remove Top Right Border" object, which allows the camera to follow the player outside the bounds of the regular room by travelling further up or to the right.
  - In most rooms you will encounter a black stip, followed by a large area of empty space, which can be good for building levels without limits on space and without needing to affect the normal parts of rooms, and without relying on Debug Mod's camera lock (which removes the smoothing from the camera).
- Added a Shadow Dash Crystal which temporarily gives/refreshes the Shadow Dash.
- Added a Start Pause setting for the Laser Crystal.
- Soul Twisters have been renamed to fix a typo (they were previously called 'Spell Twisters').
- Laser Crystal config settings now work with decimal numbers.
- Fixed an issue where the Lance Sentry was flipped the wrong way round in the editor.
- Fixed an issue where Gruz Mother would still play the explosion animation with Gruzzers disabled, and Gruzzers would spawn if placed inside the vanilla Gruz Mother room.
- Fixed an issue where Gruz Mother still had vanilla geo drops that couldn't be configured.