### PR TITLE
There is an invalid link in ModLinks's xmlns

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<ModLinks xmlns="https://github.com/HollowKnight-Modding/HollowKnight.ModLinks/HollowKnight.ModManager"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+<ModLinks xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://raw.githubusercontent.com/HollowKnight-Modding/HollowKnight.ModLinks/main/Schemas/ModLinks.xml">
     <Manifest>
         <Name>Wrong Gravity</Name>


### PR DESCRIPTION
There is an invalid link in ModLinks's xmlns.
It caused xml parsers can't work.

Sorry,my English isn't very good