### PR TITLE
Updated Architect to 1.12.1.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9485,9 +9485,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.12.0.1</Version>
-        <Link SHA256="92f9b149a1843bd39c8cab4bad3227d5483692e3226542eb6aaeda22369c5b6a">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.0.1/Architect.zip]]>
+        <Version>1.12.1.0</Version>
+        <Link SHA256="ce77bcead16f63ca11717c2fe9ae26c5a45f8922ec39d8840b9e292a00d6f9d0">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.1.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added config options to custom PNG settings for pixels per unit and filter mode.
- Added custom PNG settings to the Zote Head.
- Added an optional setting to the level sharer for an icon.
- Added a trigger layer config option to the trigger zone, only trigger zones with the same layer collide.
- Added the Z Offset setting to all moving objects.
- Fixed an issue where some custom png textures wrapped round, causing glitches on the edges of images.