### PR TITLE
Updated Architect to 1.12.3.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9485,9 +9485,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.12.2.1</Version>
-        <Link SHA256="891183308cb4f9607859282043f02d5ca31f0c339a649ba28b2954b1c2ac9309">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.2.1/Architect.zip]]>
+        <Version>1.12.3.0</Version>
+        <Link SHA256="ba3f4fbdea1f581aece15a56268379734d630849b0cc3179254454cb619ec36e">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.3.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9485,9 +9485,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.12.2.0</Version>
-        <Link SHA256="119a551afb8301c08ce8bb4db5d15aecccb0d8e7324babfd01427e5dd6cf172b">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.2.0/Architect.zip]]>
+        <Version>1.12.2.1</Version>
+        <Link SHA256="891183308cb4f9607859282043f02d5ca31f0c339a649ba28b2954b1c2ac9309">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.2.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9485,9 +9485,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.12.1.0</Version>
-        <Link SHA256="ce77bcead16f63ca11717c2fe9ae26c5a45f8922ec39d8840b9e292a00d6f9d0">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.1.0/Architect.zip]]>
+        <Version>1.12.2.0</Version>
+        <Link SHA256="119a551afb8301c08ce8bb4db5d15aecccb0d8e7324babfd01427e5dd6cf172b">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.12.2.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed some buttons being blocked due to the bindings UI being constantly active
- Fixed some objects having duplicate copies of config options
- Added a setting to disable Volatile Zotelings respawning
- Fixed an issue where the moving object preview was inaccurate
- Added the Radiance Platforms, with "up" and "down" triggers and settings to toggle whether they start up