### PR TITLE
Updated Architect to 1.15.0.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9547,9 +9547,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.14.5.0</Version>
-        <Link SHA256="ab2025fb03f0a699f207f537e46bb8082429a7f01b10c881806c771e5741400f">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.14.5.0/Architect.zip]]>
+        <Version>1.15.0.0</Version>
+        <Link SHA256="0e47cef7a932a58533b660a5a8b57c1affbeb8c11bdab420a313dd6b014346c5">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.15.0.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Pressing "C" copies the current drag tool selection, pressing "V" pastes the selection.
  - Config settings relying on IDs such as the Object Mover will be updated automatically if the object with the ID is included in the selection.
  - The offset at which the selection is pasted at will be equal to the offset from the cursor at the time of copying the selection.
  - Holding control when you paste a selection will keep your existing selection as well.
- Holding left shift as you rotate an object will now rotate it anti-clockwise.
- Added a Jump Binding which disables the player's ability to jump.
- Added an Attack Binding which disables the player's ability to swing the nail.