### PR TITLE
Updated Architect to 1.16.3.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9549,9 +9549,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.2.1</Version>
-        <Link SHA256="2430db0b3d05b9ce7feae482b714ae01e766923d05fa009e29d621246607e89d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.2.1/Architect.zip]]>
+        <Version>1.16.3.0</Version>
+        <Link SHA256="3fe054be2039081937d11996728ba6bc44eed4e7de9a9f7e867d99ec13688d04">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.3.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added a Reset Velocity setting to the Object Mover.
- Fully removed the boundaries of the Binoculars to see the entire room.