### PR TITLE
Updated Architect to 1.16.8.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9604,9 +9604,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.8.1</Version>
-        <Link SHA256="f59fe2baa3214bf584ca476323fe2d8ec69968f4272a1ea4f930afabcb2d704f">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.8.1/Architect.zip]]>
+        <Version>1.16.8.2</Version>
+        <Link SHA256="535e2bb3ff724cc3ee76cf790955fdd19e6efd7a11a1412add1c5edd038dcdfe">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.8.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Noclip in edit mode is now properly frozen when the game is paused in multiplayer.