### PR TITLE
Updated Architect to 1.16.10.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9606,7 +9606,7 @@ Enjoy!</Description>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
         <Version>1.16.10.0</Version>
-        <Link SHA256="502c480832992a1f91fc0f5b8bc1654575145748aef6621c4358cd1bf8d821fe">
+        <Link SHA256="0a57098ffd05a1c570c73cdfce012f382d31c1b39a711cb275d5be9facc6cb1a">
             <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.10.0/Architect.zip]]>
         </Link>
         <Dependencies>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9605,9 +9605,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.9.1</Version>
-        <Link SHA256="298a0587d677321d3b19723d8a457d6ccd44046a25c8dcf45936389d78e7af8c">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.9.1/Architect.zip]]>
+        <Version>1.16.10.0</Version>
+        <Link SHA256="502c480832992a1f91fc0f5b8bc1654575145748aef6621c4358cd1bf8d821fe">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.10.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added the Feather to the Abilities category, turning the player into an orb of light that can fly around.
  - The Feather is similar to the Feather in Celeste, however it doesn't function identically.
  - You can configure how long the feather lasts, and how long it should take to respawn.
- Added the White Palace Lift.
  - The lift has been reprogrammed, allowing it to travel in any direction rather than only moving directly upwards.
- Added the Dive Coffin object from the Resting Grounds.
- Added the Resting Grounds Platform S.