### PR TITLE
Updated Architect to 1.16.11.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9605,9 +9605,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.10.0</Version>
-        <Link SHA256="0a57098ffd05a1c570c73cdfce012f382d31c1b39a711cb275d5be9facc6cb1a">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.10.0/Architect.zip]]>
+        <Version>1.16.11.1</Version>
+        <Link SHA256="4c74a104d4cdff9e39a86ddd3aeeaab5aab14f825d9019ca2bc57a853baacc5e">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.11.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Added the Dream Block, a solid object which can be dashed through with the Shade Cloak, similar to the object from Celeste.
  - This has an adjustable width and height, and the dash is extended to pass through the full block. You can also use downwards dashes using Dashmaster.
  - If the player is blocked from exiting the Dream Block by a solid object (such as the ground), they will take hazard damage.
  - When sliding on the wall with the Mantis Claw, pressing dash will cause the player to dash into the block rather than away from it, passing through it when using the Shade Cloak.
  - With the Mantis Claw you can jump out as you leave the Dream Block by pressing the jump button just as you leave, launching you further than a normal wall jump. The player does a slight twirl when this happens.
- Added sound effects to the Feather and Ability Crystals.
- Added events to the Feather for when the player starts and stops flying.
- The Feather has been moved to be closer to the front of the Abilities category.
- Added a configuration option to the Ability Crystals for the respawn delay.
- Ability Crystals that respawn now leave an outline.
- Standing on a Feather or Ability Crystal as they respawn now triggers them.