### PR TITLE
Updated Architect to 1.16.11.4

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9605,9 +9605,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.11.3</Version>
-        <Link SHA256="c04760394773abfa8da81aed75e587f0d900698ef8c291ff428ae2a9b7cfb4da">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.11.3/Architect.zip]]>
+        <Version>1.16.11.4</Version>
+        <Link SHA256="6f4c05f57acc03aa6ce2ef26fbfd94eae07a9cc83d4bb44a3b25f0e9ade6dde9">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.11.4/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fix to Dream Blocks to prevent the particles from increasing in Z range when scale is increased.
- Slight tweaks to jump cutting patch.