### PR TITLE
BWR bump (x2)

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1588,9 +1588,9 @@ All with an incredible new soundtrack!</Description>
     <Manifest>
         <Name>Breakable Wall Randomizer</Name>
         <Description>A Hollow Knight Randomizer add-on for breakable walls.</Description>
-        <Version>4.1.1.0</Version>
-        <Link SHA256="50C403279B78030D5A55F3C7672D58A0646FE57310BA58A4FB0AD9754709CEB4">
-            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.1.1.0/BreakableWallRandomizer.zip]]>
+        <Version>4.1.1.1</Version>
+        <Link SHA256="E95FEEFFDC6755BAD0B93716F1F34AEFD8C8877CB42765224771EDD647E0C18B">
+            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.1.1.1/BreakableWallRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1588,9 +1588,9 @@ All with an incredible new soundtrack!</Description>
     <Manifest>
         <Name>Breakable Wall Randomizer</Name>
         <Description>A Hollow Knight Randomizer add-on for breakable walls.</Description>
-        <Version>4.1.1.1</Version>
-        <Link SHA256="E95FEEFFDC6755BAD0B93716F1F34AEFD8C8877CB42765224771EDD647E0C18B">
-            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.1.1.1/BreakableWallRandomizer.zip]]>
+        <Version>4.1.1.2</Version>
+        <Link SHA256="03D21CC850B4F41E57338339F866AA27D297AA9727AFB0E3EA5ABBEDBBD11BF8">
+            <![CDATA[https://github.com/nerthul11/BreakableWallRandomizer/releases/download/4.1.1.2/BreakableWallRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>


### PR DESCRIPTION
- Renamed Plank-Baldur_Shell to Plank-Baldur_Shell_Lower.
- Resolved false positives on Waterways_08, Beast Den Hornet & Plank, Catacombs, Ruins1_32, Deepnest_East_01.
- Resolved false negs on Cliffs_02 & Deepnest_01b.
- Solved whatever bongcloud I had done with Bench-Mimic's_Secret.
- Some catacomb collapsers will now make parts of the room visible.
- Pulled a patch skip and ignored 4.1.1.1, it does not exist.