### PR TITLE
Updated Architect to 1.16.12.4

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9715,9 +9715,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.12.3</Version>
-        <Link SHA256="919ec8b866fb88774ae24b5a32da08c1c28c22853d5da3de5eebd6ee7cebdc5d">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.12.3/Architect.zip]]>
+        <Version>1.16.12.4</Version>
+        <Link SHA256="92462883ef695ef9e4b38a9bb2f9f54f21bcab840bc92db65d689fde620ec025">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.12.4/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fix to wind fall time reset as code was in the wrong place.