### PR TITLE
Change charm crab link to source-built version

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -1597,8 +1597,8 @@ All with an incredible new soundtrack!</Description>
         <Name>Charm Crab</Name>
         <Description>New Charm Mechanics, New Charms, New Spells, and Rebalances</Description>
         <Version>1.0.8.0</Version>
-        <Link SHA256="8c56a904547e217d89def3d39b89ce8a1e4893ad7afd0d25f5e17d2b2e74013a">
-            <![CDATA[https://github.com/DistractionCrab/Charm-Crab/releases/download/v1.0.8/CharmCrab-1-0-8.zip]]></Link>
+        <Link SHA256="f277d8f117bab515f9e65c89aee85644fe370e19a25d98f09c41dc601d8be76a">
+            <![CDATA[https://github.com/HK-Modding-Preservation/Charm-Crab/releases/download/v1.0.8/CharmCrab.zip]]></Link>
         <Dependencies>
             <Dependency>Vasi</Dependency>
             <Dependency>SFCore</Dependency>


### PR DESCRIPTION
using the source from hk-modding-preservation.

cc @DistractionCrab 

will fix https://github.com/hk-modding/modlinks/issues/2172