### PR TITLE
Updated Architect to 1.16.14.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9721,9 +9721,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.14.0</Version>
-        <Link SHA256="33d97047f8a68dc460d9f1c66ebbcb9a57359fff7e24def1bd7bacdeabd89894">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.14.0/Architect.zip]]>
+        <Version>1.16.14.1</Version>
+        <Link SHA256="cb34342b19a9fc6058f6a6c8652e5d850e3119c988eab0f40688fd6b8ce1692a">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.14.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where the Arena option for the Broken Vessel's balloon spawning was broken.