### PR TITLE
Update MultiWorld to 1.2.4

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -3032,18 +3032,14 @@ All with an incredible new soundtrack!</Description>
     </Manifest>
     <Manifest>
         <Name>MultiWorld</Name>
-        <Description>A RandomizerMod 4 add-on for distributing players' items between all their worlds. The default IP no longer works. Please use `mw.hkmp.org` if you want to connect to the public server.</Description>
-        <Version>1.2.3.0</Version>
-        <Link SHA256="337368A186B960C27C94D91C11F1BFD8ED91286438DBD335167E30BCCF7481BC">
-            <![CDATA[https://github.com/Shadudev/HollowKnight.MultiWorld/releases/download/multiworld-v1.2.3/MultiWorldMod.zip]]>
-        </Link>
+        <Description>A RandomizerMod 4 add-on for distributing players&#39; items between all their worlds.</Description>
+        <Version>1.2.4.0</Version>
+        <Link SHA256="c40b0295e3ac4936b7ec4519b584809eacc51e95607e9af850b2282ae3d7d5f9">https://github.com/dpinela/HollowKnight.MultiWorld/releases/download/multiworld-v1.2.4/MultiWorldMod.zip</Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>
             <Dependency>MultiWorldLib</Dependency>
         </Dependencies>
-        <Repository>
-            <![CDATA[https://github.com/Shadudev/HollowKnight.MultiWorld/]]>
-        </Repository>
+        <Repository>https://github.com/dpinela/HollowKnight.MultiWorld/</Repository>
     </Manifest>
     <Manifest>
         <Name>MultiWorldLib</Name>


### PR DESCRIPTION
Also removing the outdated advice in the description; the mod already uses mw.hkmp.org as its default server.