### PR TITLE
Updated Architect to 1.16.15.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9777,9 +9777,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.16.15.0</Version>
-        <Link SHA256="5cc34a947fde42187f3bfd79d7577e5d7173d44fe846bc4c344511aff64b69bc">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.15.0/Architect.zip]]>
+        <Version>1.16.15.1</Version>
+        <Link SHA256="36e9b0297311baa2089d675ce9e44ae77dcdd718c5bfb32ac0324be33b9fcf5d">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.16.15.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
Changed the Zote Trophy's winner display to work like the Flea Counter custom title in Silksong Architect for better reliability