### PR TITLE
Updated Architect to 1.18.0.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9777,9 +9777,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A level editor mod, allowing you to customise Hollow Knight by adding or removing platforms, enemies and more with an in-game level editor and level sharer.</Description>
-        <Version>1.18.0.1</Version>
-        <Link SHA256="880beebae9db4c3baa268bca1ae527d909e7a12db794e835a8637bc557458866">
-            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.18.0.1/Architect.zip]]>
+        <Version>1.18.0.2</Version>
+        <Link SHA256="22c8e81e5453c6bd1f2cb46dd525c8f7c27c1d7ef0cbc232b8a733bd4f7b190d">
+            <![CDATA[https://github.com/cometcake575/Architect/releases/download/1.18.0.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed UI overlapping on some resolutions.
- Increased scale of objects in the UI.
- Fixed a bug where having preloads with objects from disabled content packs crashed the mod.