### PR TITLE
Update SafeGodseekerQoL to version 1.0.0.3

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -9517,14 +9517,15 @@ Enjoy!</Description>
     <Manifest>
         <Name>SafeGodseekerQoL</Name>
         <Description>This mod is useful for challenge runners who don't want their runs to be accidentally affected by QoL mods.</Description>
-        <Version>1.0.0.2</Version>
-        <Link SHA256="df6fbe3bed27237c88cb71650c7107137627209d671cc1b225a852f496f40343">
-            <![CDATA[https://github.com/NightFuryoOo/SafeGodSeekerQoL/releases/download/v1.0.0.2/SafeGodseekerQoL.zip]]>
+        <Version>1.0.0.3</Version>
+        <Link SHA256="908c3eef9fbb3cdad61eae2b068e8f36055cd8416d355fd94ef4ded246947eff">
+            <![CDATA[https://github.com/NightFuryoOo/SafeGodSeekerQoL/releases/download/v1.0.0.3/SafeGodseekerQoL.zip]]>
         </Link>
          <Dependencies>
              <Dependency>Osmi</Dependency>
              <Dependency>Satchel</Dependency>
              <Dependency>Vasi</Dependency>
+			 <Dependency>SFCore</Dependency>
          </Dependencies>
         <Repository>
             <![CDATA[https://github.com/NightFuryoOo/SafeGodSeekerQoL]]>


### PR DESCRIPTION
1.Added tools for improving the Collector fight:
1.1 Changing the HP of summons;
1.2 Adjusting the summon limit;
1.3 Changing the Collector’s HP;
1.4 Modifying the HP threshold at which the Collector switches phases; 
1.5 Enabling or disabling the spawn of specific enemies (for example, making only Aspids appear in jars); 
1.6 Other useful features.

2.Added new ways to manipulate the DreamShield: adjusting rotation speed and adding a delay before rotation begins;

3.Added the ability to perform an instant SuperDash with adjustable speed (up to 10×) and the option to enable it in all locations;

4.Added the ability to use teleporters, similar to those in the QoLTeleportKit mod, with minor improvements and the removal of unnecessary teleport points;