### PR TITLE
Update ProfanityFilterAddon version and link

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10875,9 +10875,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>ProfanityFilterAddon</Name>
         <Description>Server-side profanity filter addon for HKMP and SSMP. currently uses a high-performance rule-based filtering engine.</Description>
-        <Version>1.0.0.0</Version>
-        <Link SHA256="064547A522D5B1055B52A96F080F7E4738FE0B7D625327833438F197D5E01704">
-            <![CDATA[https://github.com/diamondpixel/ProfanityFilterAddon/releases/download/v1.0.0/ProfanityFilterAddon-HKMP.zip]]>
+        <Version>1.1.0.0</Version>
+        <Link SHA256="df5730c63a45a1266f984ace2c3ee3903a05b29d8fa934756e1ea18a4f9ad9e2">
+            <![CDATA[https://github.com/diamondpixel/ProfanityFilterAddon/releases/download/v1.1.0/ProfanityFilterAddon-Client.zip]]>
         </Link>
         <Dependencies>
             <Dependency>HKMP</Dependency>


### PR DESCRIPTION
Updated DLL to correctly instatiate and work with HKMP instead of expecting to be placed next to HKMP dll.