### PR TITLE
Update GodhomeQoL v1.0.1.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10076,16 +10076,15 @@ Enjoy!</Description>
     </Manifest>
     <Manifest>
         <Name>GodhomeQoL</Name>
-        <Description>This mod is useful for challenge runners who don't want their runs to be accidentally affected by QoL mods.</Description>
-        <Version>1.0.0.9</Version>
-        <Link SHA256="025b319c15551cd3a3e1359a9b235c00a89e6354ce3f61899a9ef25d46d70539">
-            <![CDATA[https://github.com/NightFuryoOo/GodhomeQoL/releases/download/v1.0.0.9/GodhomeQoL.zip]]>
+        <Description>This mod is a large collection of tools designed to help challenge runners with their tasks.</Description>
+        <Version>1.0.1.0</Version>
+        <Link SHA256="d0643fa0637d0411aa2b247af230ec50675d3b65b4433f5b6697273b49e5a3ab">
+            <![CDATA[https://github.com/NightFuryoOo/GodhomeQoL/releases/download/v1.0.1.0/GodhomeQoL.zip]]>
         </Link>
          <Dependencies>
              <Dependency>Osmi</Dependency>
              <Dependency>Satchel</Dependency>
              <Dependency>Vasi</Dependency>
-             <Dependency>SFCore</Dependency>
          </Dependencies>
         <Repository>
             <![CDATA[https://github.com/NightFuryoOo/GodhomeQoL]]>


### PR DESCRIPTION
1.Multiple bugs have been fixed.

2.The Boss Manipulate mod has been added.
[This mod allows you to change bosses’ HP, their phase transition HP thresholds, the HP of their summons, their limits, and the number of them that can be on the arena at the same time.]

3.SFCore has been removed from the project dependencies.