### PR TITLE
Add 'Charm Loadouts' mod manifest

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -11811,4 +11811,23 @@ Enjoy!</Description>
             <Author>kaycodes13</Author>
         </Authors>
     </Manifest>
+		<Manifest>
+    <Name>Charm Loadouts</Name>
+    <Description>Allows you to save and load up to 3 charm builds while resting at a bench.</Description>
+    <Version>v1.5.0.0</Version>
+    <Link SHA256="A8F0F9051FC1EB94EF219F1F29A902C0BA6B22830185082D3B56E68D94786349"><![CDATA[https://github.com/CompTech21/CharmLoadouts/releases/download/1.5.0.0/CharmLoadouts.dll]]></Link>
+    <Dependencies>
+        <Dependency>Satchel</Dependency>
+    </Dependencies>
+    <Repository>
+        <![CDATA[https://github.com/CompTech21/CharmLoadouts.git]]>
+    </Repository>
+    <Tags>
+        <Tag>Gameplay</Tag>
+    </Tags>
+    <Authors>
+        <Author>CompTech21</Author>
+    </Authors>
+</Manifest>
+	
 </ModLinks>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -11811,23 +11811,24 @@ Enjoy!</Description>
             <Author>kaycodes13</Author>
         </Authors>
     </Manifest>
-		<Manifest>
-    <Name>Charm Loadouts</Name>
-    <Description>Allows you to save and load up to 3 charm builds while resting at a bench.</Description>
-    <Version>v1.5.0.0</Version>
-    <Link SHA256="A8F0F9051FC1EB94EF219F1F29A902C0BA6B22830185082D3B56E68D94786349"><![CDATA[https://github.com/CompTech21/CharmLoadouts/releases/download/1.5.0.0/CharmLoadouts.dll]]></Link>
-    <Dependencies>
-        <Dependency>Satchel</Dependency>
-    </Dependencies>
-    <Repository>
-        <![CDATA[https://github.com/CompTech21/CharmLoadouts.git]]>
-    </Repository>
-    <Tags>
-        <Tag>Gameplay</Tag>
-    </Tags>
-    <Authors>
-        <Author>CompTech21</Author>
-    </Authors>
-</Manifest>
-	
+    <Manifest>
+        <Name>Charm Loadouts</Name>
+        <Description>Allows you to save and load up to 3 charm builds while resting at a bench.</Description>
+        <Version>1.5.0.0</Version>
+        <Link SHA256="A8F0F9051FC1EB94EF219F1F29A902C0BA6B22830185082D3B56E68D94786349">
+            <![CDATA[https://github.com/CompTech21/CharmLoadouts/releases/download/1.5.0.0/CharmLoadouts.dll]]>
+        </Link>
+        <Dependencies>
+            <Dependency>Satchel</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/CompTech21/CharmLoadouts.git]]>
+        </Repository>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+        <Authors>
+            <Author>CompTech21</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
Added a new manifest for the 'Charm Loadouts' mod with details including name, description, version, download link, dependencies, repository, tags, and authors.