### PR TITLE
Add PathOfPureVessel mod

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -11944,4 +11944,25 @@ Enjoy!</Description>
             <Author>CompTech21</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>PathOfPureVessel</Name>
+        <Description>Adds a Path of Pure Vessel boss fight in White Palace. Prepare to Die.</Description>
+        <Version>1.5.1</Version>
+        <Link SHA256="27CF55B1844D75BEF1CEBC525D4EFADF137C82151278BD5A8BFE77F49C4FDCFA">
+            <![CDATA[https://github.com/overabstractor/PathOfPureVessel/releases/download/v1.5.1/PVPoP.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>Satchel</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/overabstractor/PathOfPureVessel.git]]>
+        </Repository>
+        <Tags>
+            <Tag>Boss</Tag>
+            <Tag>Expansion</Tag>
+        </Tags>
+        <Authors>
+            <Author>overabstractor</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
## Mod info

| Field | Value |
|-------|-------|
| **Name** | PathOfPureVessel |
| **Author** | overabstractor |
| **Version** | 1.5.1 |
| **Dependency** | Satchel |
| **Tags** | Boss, Expansion |

## Description

Adds a Path of Pure Vessel boss fight in White Palace (White_Palace_20). The mod replaces the Royal Guards with the Pure Vessel (HK Prime) with modified behavior and attack patterns.

## v1.5.1 release notes

- Fix: crash when used alongside Custom Knight. The boss FSM contained stale scene references (SetFsmGameObject) from the GG_Hollow_Knight prefab that caused a native crash in GetComponents on the first attack when Custom Knight was active.

## Verification

- [x] GitHub release published with verified SHA256
- [x] Satchel dependency declared correctly
- [x] Public and accessible repository