### PR TITLE
Updated Architect to 3.28.0.5, Added UltimateChickenKnight

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10689,9 +10689,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.28.0.4</Version>
-        <Link SHA256="cf6ba6390885ee424d0655396f62281479990c7ade29f55b7935607ada2d1df3">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.28.0.4/Architect.zip]]>
+        <Version>3.28.0.5</Version>
+        <Link SHA256="ecf5ab00b5259285d9ca02168be1b2d8953cba4a3ca1972f051d0f2056f5c565">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.28.0.5/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>
@@ -10707,6 +10707,30 @@ Enjoy!</Description>
         <Integrations>
             <Integration>HKMP</Integration>
         </Integrations>
+        <Tags>
+            <Tag>Gameplay</Tag>
+        </Tags>
+        <Authors>
+            <Author>cometcake575</Author>
+        </Authors>
+    </Manifest>
+    <Manifest>
+        <Name>UltimateChickenKnight</Name>
+        <Description>Ultimate Chicken Horse in Hollow Knight, using HKMP and the Architect mod.</Description>
+        <Version>3.28.0.5</Version>
+        <Link SHA256="096c337ee5442f2bb29cd6a5e5f9db3fd296e93f60623b4d9c2bbb15d10fab39">
+            <![CDATA[https://github.com/cometcake575/UltimateChickenKnight/releases/download/1.0.10.0/UltimateChickenKnight.zip]]>
+        </Link>
+        <Dependencies>
+            <Dependency>Architect</Dependency>
+            <Dependency>HKMP</Dependency>
+        </Dependencies>
+        <Repository>
+            <![CDATA[https://github.com/cometcake575/UltimateChickenKnight]]>
+        </Repository>
+        <Issues>
+            <![CDATA[https://github.com/cometcake575/UltimateChickenKnight/issues]]>
+        </Issues>
         <Tags>
             <Tag>Gameplay</Tag>
         </Tags>


### PR DESCRIPTION
Architect: Fixed the player attacks block in Architect not working and made changes to support UltimateChickenKnight

UltimateChickenKnight: An HKMP addon to play Ultimate Chicken Horse in Hollow Knight