### PR TITLE
Fix Ultimate Chicken Knight version

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10738,7 +10738,7 @@ Enjoy!</Description>
     <Manifest>
         <Name>UltimateChickenKnight</Name>
         <Description>Ultimate Chicken Horse in Hollow Knight, using HKMP and the Architect mod.</Description>
-        <Version>1.0.10.0</Version>
+        <Version>4.0.10.0</Version>
         <Link SHA256="096c337ee5442f2bb29cd6a5e5f9db3fd296e93f60623b4d9c2bbb15d10fab39">
             <![CDATA[https://github.com/cometcake575/UltimateChickenKnight/releases/download/1.0.10.0/UltimateChickenKnight.zip]]>
         </Link>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10738,7 +10738,7 @@ Enjoy!</Description>
     <Manifest>
         <Name>UltimateChickenKnight</Name>
         <Description>Ultimate Chicken Horse in Hollow Knight, using HKMP and the Architect mod.</Description>
-        <Version>3.28.0.5</Version>
+        <Version>1.0.10.0</Version>
         <Link SHA256="096c337ee5442f2bb29cd6a5e5f9db3fd296e93f60623b4d9c2bbb15d10fab39">
             <![CDATA[https://github.com/cometcake575/UltimateChickenKnight/releases/download/1.0.10.0/UltimateChickenKnight.zip]]>
         </Link>


### PR DESCRIPTION
Should be 1.0.10.0, accidentally left it as the Architect version number