### PR TITLE
Updated Architect to 3.28.0.8

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10705,9 +10705,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.28.0.7</Version>
-        <Link SHA256="a1a5e08a18153d5894396420572418754ce904956eceaf289856ec6b61969f3c">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.28.0.7/Architect.zip]]>
+        <Version>3.28.0.8</Version>
+        <Link SHA256="0dd3d5916b1c94a8a137f488adf56aaf5de6e7c5baf465c009d0ac67ab39b242">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.28.0.8/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where levels did not download properly from the level sharer
- Fixed issues where custom assets did not load properly
- Added the Queen's Gardens door
- Added Cloth (Ally)
- Added the Shade
- Added the Camera and Camera View objects from the Silksong version