### PR TITLE
Update Gatling Aspid to 1.1.1.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -6182,19 +6182,26 @@ Enjoy!</Description>
     <Manifest>
         <Name>Gatling Aspid</Name>
         <Description>Makes primal aspids wield gatling miniguns; configuration options available.</Description>
-        <Version>1.0.0.2</Version>
-        <Link SHA256="c9686e82bca1ef891ce6c0c1e88c06f46f289807ffe955a5e604dc93fd4147e8">
-            <![CDATA[https://github.com/jngo102/GatlingAspid/releases/download/e64c80a09b934a081534/GatlingAspid.zip]]>
+        <Version>1.1.1.0</Version>
+        <Link SHA256="F9DF9EFB8899749ABD25347D068E4E8BF4840DA706452F2BDE49B346D7CC70EE">
+            <![CDATA[https://github.com/Ballaii/GatlingAspidExtended/releases/download/v1.1.1.0/GatlingAspid-v1.1.1.0.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Vasi</Dependency>
         </Dependencies>
         <Repository>
-            <![CDATA[https://github.com/jngo102/GatlingAspid/]]>
+            <![CDATA[https://github.com/Ballaii/GatlingAspidExtended]]>
         </Repository>
+        <Issues>
+            <![CDATA[https://github.com/Ballaii/GatlingAspidExtended/issues]]>
+        </Issues>
         <Tags>
             <Tag>Gameplay</Tag>
         </Tags>
+        <Authors>
+            <Author>jngo102</Author>
+            <Author>Ballaii</Author>
+        </Authors>
     </Manifest>
     <Manifest>
         <Name>Aspid Queen</Name>


### PR DESCRIPTION
Updates the existing `Gatling Aspid` entry to the tested replacement build `1.1.1.0`.

Changes:
- Replaces the old download URL with the `Ballaii/GatlingAspidExtended` release asset.
- Updates SHA256 for the exact release zip.
- Keeps the same `Gatling Aspid` manifest name so this replaces the existing entry rather than adding a duplicate.
- Adds issue tracker and authors metadata.

Validation:
- Confirmed the mod loads in-game and restores the original minigun Aspid behavior.
- `xmllint --noout --schema Schemas/ModLinks.xml ModLinks.xml` passes locally.
- Downloaded release asset SHA256 matches the manifest hash.

Original author permission:
https://github.com/jngo102/GatlingAspid/issues/2#issuecomment-4633633124