### PR TITLE
Updated Architect to 3.29.2.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10798,9 +10798,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.29.1.0</Version>
-        <Link SHA256="857f10372598e6213eba5ac5bc28d453f6f8cd25dd836f1602dec94eb0f968a8">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.29.1.0/Architect.zip]]>
+        <Version>3.29.2.0</Version>
+        <Link SHA256="334971484876140ee762e32e3307be08918f759193434487ac6a0086cc27d65b">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.29.2.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed some issues with previewed objects triggering behaviour when they shouldn't
- Added the Toggle Layer block, which can be used for enabling/disabling all objects in a specific layer
- Added the Water Area and the Acid Area