### PR TITLE
Updated Architect to 3.29.3.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10835,9 +10835,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.29.3.1</Version>
-        <Link SHA256="3e6acb930be7eeabe98e8bd976e123a11c724df6ae8a816075412bcbcea78786">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.29.3.1/Architect.zip]]>
+        <Version>3.29.3.2</Version>
+        <Link SHA256="71a1f217fbc95a59e66f6ae821dc23056e9bcb2e18cb9884cc408062a219f04e">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.29.3.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where the Laser Crystal beam would extend beyond the object it hit when scaled up
- Fixed the Hazard option on coloured objects not working
- Fixed Custom WAVs not loading properly in edit mode