### PR TITLE
Updated Architect to 3.30.0.0

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10907,9 +10907,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.29.3.3</Version>
-        <Link SHA256="f38e936a83b55313e3fa6fb0e9e0497cf92cd35d871e93099190992d6b47e636">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.29.3.3/Architect.zip]]>
+        <Version>3.30.0.0</Version>
+        <Link SHA256="f0bf11d4b46f448ad3a61399dce64a31506b7db2f87ce14be178832bd2a6bbde">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.30.0.0/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed issues with some objects no longer having varied z offsets, leading to z fighting
- Fixed an issue where the Gameplay Control block was not available in the Script Editor
- Added a FindObject trigger to the Object Hook, which will re-scan for the target object, for when objects are in additively loaded scenes
  - When used alongside things like the FSM Hook, these should be disabled until the FindObject trigger is run
- Added the Object Collision Changer, which can disable collision between two specific objects
  - Collision can also be re-enabled after, however it is not possible to enable collision between objects whose layers do not normally collide
- Objects are now only loaded when needed to improve load times and memory usage