### PR TITLE
Update GodhomeQoL version to 1.0.1.3

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10585,9 +10585,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>GodhomeQoL</Name>
         <Description>This mod is a large collection of tools designed to help challenge runners with their tasks.</Description>
-        <Version>1.0.1.2</Version>
-        <Link SHA256="b072267cfb4f6403eb91519e1584876f7774add5df2bda659d69428a7fa71a76">
-            <![CDATA[https://github.com/NightFuryoOo/GodhomeQoL/releases/download/v1.0.1.2/GodhomeQoL.zip]]>
+        <Version>1.0.1.3</Version>
+        <Link SHA256="a5fc55e3987251b66eec364bfb053be34826b4ab1801b98b1cace4e1a9fdab45">
+            <![CDATA[https://github.com/NightFuryoOo/GodhomeQoL/releases/download/v1.0.1.3/GodhomeQoL.zip]]>
         </Link>
          <Dependencies>
              <Dependency>Osmi</Dependency>


### PR DESCRIPTION
1.Improved Boss Manipulate support when entering bosses from GG_Atrium and GG_Atrium_Roof.

2.Fixed Boss Manipulate affecting Pantheon fights when it should not.

3.Fixed phase HP limits: phase thresholds now respect the configured Max HP.

4.Fixed phase behavior for Pure Vessel, Nightmare King Grimm, Hive Knight, Hornet Sentinel and related bosses.

5.Fixed False Knight / Failed Champion phase HP restore logic.

6.Added option to skip Pantheon V ending cutscenes.

7.Fixed Cheats toggles not saving correctly after closing the game with Alt+F4.