### PR TITLE
Updated Architect to 3.31.0.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10907,9 +10907,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.31.0.0</Version>
-        <Link SHA256="4e26c12acb54400d017977219516353b63ba99817cafdf7cb291f60bad6410c8">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.31.0.0/Architect.zip]]>
+        <Version>3.31.0.1</Version>
+        <Link SHA256="f5feaa472f31fa17b2b51be1fec28f25158ed10af2b0068dfe5cc68806b52b16">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.31.0.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where having multiple Object Extractors with the same target would not work