### PR TITLE
Update HKBattle version to 1.0.0.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10629,9 +10629,9 @@ Enjoy!</Description>
      <Manifest>
         <Name>HKBattle</Name>
         <Description>HKBattle is a Hollow Knight mod for solo practice and competitive boss and Pantheon challenges.</Description>
-        <Version>1.0.0.1</Version>
-        <Link SHA256="e120dd9240c4ef27554617a50cac2007fffe58c69fc4475e0fe53146e528b3ea">
-            <![CDATA[https://github.com/NightFuryoOo/HKBattle/releases/download/v1.0.0.1/HKBattle.zip]]>
+        <Version>1.0.0.2</Version>
+        <Link SHA256="7c9df967d05b745b44cd8d0d610843b7eb3cf906450bc117142760502f610850">
+            <![CDATA[https://github.com/NightFuryoOo/HKBattle/releases/download/v1.0.0.2/HKBattle.zip]]>
         </Link>
          <Dependencies>
          </Dependencies>


### PR DESCRIPTION
Fixed false battle completion during Pantheon boss transitions, which could cause battle settings to be restored too early.