### PR TITLE
Updated Architect to 3.31.4.2

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -10947,9 +10947,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.31.4.1</Version>
-        <Link SHA256="3fe37049beeb63f2ce5b5943e2c115143f5084fde102fb94b4966d2d444a034a">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.31.4.1/Architect.zip]]>
+        <Version>3.31.4.2</Version>
+        <Link SHA256="11a969bf36a20c5fdb7622761b823f0b746c5a0ba28947f233760b651b50994c">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.31.4.2/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where the UI for converting DcM maps manually didn't work
- Levels using 'Mana' in DecorationMaster can now be converted to Architect levels, with a custom mana inventory item used to represent mana and prefab equivalents to mana-related objects