### PR TITLE
Add Halallow Knight mod details to ModLinks.xml

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -12927,6 +12927,7 @@ Enjoy!</Description>
         </Issues>
         <Tags>
             <Tag>Cosmetic</Tag>
+            <Tag>LLM-Assisted</Tag>
         </Tags>
         <Authors>
             <Author>akhihaani</Author>

--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -12907,4 +12907,29 @@ Enjoy!</Description>
             <Author>Ishmael</Author>
         </Authors>
     </Manifest>
+    <Manifest>
+        <Name>HalallowKnight</Name>
+        <DisplayName>Halallow Knight</DisplayName>
+        <Description>Rewords the game's religious and supernatural framing - gods, worship, magic, souls, charms, dreams and the dead - into neutral alternatives. Text only: no gameplay, scenes or game files are touched.</Description>
+        <Version>1.0.0.0</Version>
+        <Link SHA256="0761AB7CA9F1BDCFD2BD5EB087BE5ABE03B6AFD6D1B8626AAA109F66A78C8247">
+            <![CDATA[https://github.com/akhihaani/Halallow-Knight/releases/download/v1.0.0/HalallowKnight-1.0.0.zip]]>
+        </Link>
+        <Dependencies />
+        <Repository>
+            <![CDATA[https://github.com/akhihaani/Halallow-Knight]]>
+        </Repository>
+        <ReadMe>
+            <![CDATA[https://github.com/akhihaani/Halallow-Knight/raw/refs/heads/main/README.md]]>
+        </ReadMe>
+        <Issues>
+            <![CDATA[https://github.com/akhihaani/Halallow-Knight/issues]]>
+        </Issues>
+        <Tags>
+            <Tag>Cosmetic</Tag>
+        </Tags>
+        <Authors>
+            <Author>akhihaani</Author>
+        </Authors>
+    </Manifest>
 </ModLinks>


### PR DESCRIPTION
Halallow Knight rewords the game's religious and supernatural framing — gods, worship, prayer, idols, magic, spells, SOUL, charms, dreams and the depiction of the dead — into neutral alternatives, for players who would rather not have that content. It was written from an Islamic perspective but is not faith-specific.

It hooks ModHooks.LanguageGetHook and nothing else. No gameplay, scenes, entities or FSMs are touched, and no game files or assets are modified — everything happens at runtime, in memory. That also means it is local to the player, so it is safe alongside multiplayer mods.

Source: https://github.com/akhihaani/Halallow-Knight Every change is documented with before-and-after text in REWORDS.md, along with everything deliberately left unchanged.

Removes content rather than adding any, so it stays within Hollow Knight's own age rating. No dependencies.