### PR TITLE
Updated Architect to 3.33.0.1

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -11044,9 +11044,9 @@ Enjoy!</Description>
     <Manifest>
         <Name>Architect</Name>
         <Description>A Hollow Knight level editor mod, easily make and share custom levels with an in-game level editor and level sharer.</Description>
-        <Version>3.32.7.1</Version>
-        <Link SHA256="dd6d79da6d92581c8932b84bdb6b93222d6abe5b1811916218746b4b2ec487b7">
-            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.32.7.1/Architect.zip]]>
+        <Version>3.33.0.1</Version>
+        <Link SHA256="0ed36899ca1660af97d16c2fa04cc65df9610df834527e16d2eb7c758577bb69">
+            <![CDATA[https://github.com/cometcake575/Architect-HK/releases/download/3.33.0.1/Architect.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Satchel</Dependency>


### PR DESCRIPTION
- Fixed an issue where the player could not be targeted from within a prefab
- Added hotbar saving and loading, up to 9 hotbars can be saved using Control + [number], then loaded using Alt + [number]
  - Tab and Shift + Tab can be used to cycle through your saved hotbars
- Added the Camera Lock Area, with config options for collider and lock size and offset
  - This is how vanilla camera locks are handled, and applies a smoothing effect when locking the camera rather than being instant
- Added the Perfect Coloured Circle, which is a Perfect Coloured Circle
- Added Save, SaveQuit and CloseGame triggers to the Gameplay Control block
- Added the Grade Marker, replacing the Set Lighting block
  - This can be used to change the tint of the player's light ring and the room's general colour, and has config options for the radius in which this happens, allowing for a gradual effect